### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/modules/capture/mod.rs
+++ b/src/modules/capture/mod.rs
@@ -184,8 +184,8 @@ static BXT_CAP_STOP: Command = Command::new(
 );
 
 fn cap_stop(marker: MainThreadMarker) {
+    let mut state = STATE.borrow_mut(marker);
     unsafe {
-        let mut state = STATE.borrow_mut(marker);
         if let State::Recording(ref mut recorder) = *state {
             match recorder.record_last_frame() {
                 Ok(()) => {

--- a/src/modules/demo_playback.rs
+++ b/src/modules/demo_playback.rs
@@ -146,10 +146,11 @@ fn find_demos(prefix: PathBuf) -> Result<Vec<(PathBuf, usize)>, String> {
 pub fn set_next_demo(marker: MainThreadMarker) {
     let mut demos = DEMOS.borrow_mut(marker);
 
-    unsafe {
+    
         // Safety: no engine functions are called while the reference is active.
-        let cls_demos = &mut *engine::cls_demos.get(marker);
+        let cls_demos = unsafe { &mut *engine::cls_demos.get(marker) };
 
+    
         match demos.pop() {
             Some(demo) => {
                 // Replace the first startdemos entry with the next demo and set the next demo as
@@ -165,5 +166,4 @@ pub fn set_next_demo(marker: MainThreadMarker) {
                 cls_demos.demos[0][0] = 0;
             }
         }
-    }
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 


Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 