### PR TITLE
capture: Use wrapping multiplication for sample pairs

### DIFF
--- a/src/modules/capture/mod.rs
+++ b/src/modules/capture/mod.rs
@@ -427,8 +427,12 @@ pub unsafe fn on_s_transfer_stereo_16(marker: MainThreadMarker, end: i32) {
         .zip(buf.chunks_exact_mut(4))
     {
         // Clamping as done in Snd_WriteLinearBlastStereo16().
-        let l16 = ((sample.left * volume) >> 8).min(32767).max(-32768) as i16;
-        let r16 = ((sample.right * volume) >> 8).min(32767).max(-32768) as i16;
+        let l16 = ((sample.left.wrapping_mul(volume)) >> 8)
+            .min(32767)
+            .max(-32768) as i16;
+        let r16 = ((sample.right.wrapping_mul(volume)) >> 8)
+            .min(32767)
+            .max(-32768) as i16;
 
         buf[0..2].copy_from_slice(&l16.to_le_bytes());
         buf[2..4].copy_from_slice(&r16.to_le_bytes());


### PR DESCRIPTION
It was overflowing because of the bugged gauss charge sound in the Steam version.