### PR TITLE
Force SDL_WaitEventTimeout to 0 on bxt-rs side

### DIFF
--- a/src/hooks/sdl.rs
+++ b/src/hooks/sdl.rs
@@ -91,7 +91,7 @@ fn open_library() -> Option<libloading::Library> {
 ///
 /// [`reset_pointers()`] must be called before SDL is unloaded so the pointers don't go stale.
 #[instrument(name = "sdl::find_pointers", skip_all)]
-pub unsafe fn find_pointers(marker: MainThreadMarker) { 
+pub unsafe fn find_pointers(marker: MainThreadMarker) {
     let library = match open_library() {
         Some(library) => library,
         None => {
@@ -178,7 +178,7 @@ pub mod exported {
     pub unsafe extern "C" fn my_SDL_WaitEventTimeout(event: *mut c_void, time: c_int) -> c_int {
         abort_on_panic(move || {
             let marker = MainThreadMarker::new();
-            
+
             SDL_WaitEventTimeout.get(marker)(event, 0)
         })
     }

--- a/src/hooks/sdl.rs
+++ b/src/hooks/sdl.rs
@@ -175,7 +175,7 @@ pub mod exported {
     }
 
     #[export_name = "SDL_WaitEventTimeout"]
-    pub unsafe extern "C" fn my_SDL_WaitEventTimeout(event: *mut c_void, time: c_int) -> c_int {
+    pub unsafe extern "C" fn my_SDL_WaitEventTimeout(event: *mut c_void, _time: c_int) -> c_int {
         abort_on_panic(move || {
             let marker = MainThreadMarker::new();
 


### PR DESCRIPTION
On parity with BunnymodXT to allow game to run in full performance in background, aka InActive.