### PR TITLE
Add bxt_play_folder

### DIFF
--- a/src/modules/demo_playback.rs
+++ b/src/modules/demo_playback.rs
@@ -22,7 +22,7 @@ impl Module for DemoPlayback {
     }
 
     fn commands(&self) -> &'static [&'static Command] {
-        static COMMANDS: &[&Command] = &[&BXT_PLAY_RUN];
+        static COMMANDS: &[&Command] = &[&BXT_PLAY_RUN, &BXT_PLAY_FOLDER];
         COMMANDS
     }
 
@@ -46,10 +46,34 @@ Plays back all `name_N.dem` demos in order.",
     ),
 );
 
+static BXT_PLAY_FOLDER: Command = Command::new(
+    b"bxt_play_folder\0",
+    handler!(
+        "bxt_play_folder <folder>
+        
+Plays back all demos in the folder in alphabetic order.",
+        play_folder as fn(_, _)
+    ),
+);
+
 fn play_run(marker: MainThreadMarker, prefix: PathBuf) {
+    play(marker, &prefix, run_demos_by_number);
+}
+
+fn play_folder(marker: MainThreadMarker, folder: PathBuf) {
+    play(marker, &folder, demos_alphabetically);
+}
+
+fn play<F, I>(marker: MainThreadMarker, name: &Path, enumerate_demos: F)
+where
+    F: FnOnce(&Path) -> Result<I, String>,
+    I: DoubleEndedIterator<Item = PathBuf>,
+{
     if !DemoPlayback.is_enabled(marker) {
         return;
     }
+
+    DEMOS.borrow_mut(marker).clear();
 
     let game_dir = Path::new(
         unsafe { CStr::from_ptr(engine::com_gamedir.get(marker).cast()) }
@@ -57,12 +81,9 @@ fn play_run(marker: MainThreadMarker, prefix: PathBuf) {
             .unwrap(),
     );
     let mut full_prefix: PathBuf = game_dir.into();
-    full_prefix.push(&prefix);
+    full_prefix.push(name);
 
-    let mut demos = DEMOS.borrow_mut(marker);
-    demos.clear();
-
-    let paths = match find_demos(full_prefix) {
+    let paths = match enumerate_demos(&full_prefix) {
         Ok(paths) => paths,
         Err(err) => {
             con_print(marker, &format!("Error: {}.\n", err));
@@ -70,17 +91,67 @@ fn play_run(marker: MainThreadMarker, prefix: PathBuf) {
         }
     };
 
-    if paths.is_empty() {
-        con_print(marker, "Error: no demos found.\n");
-        return;
-    }
+    let paths = paths.map(|path| {
+        path.strip_prefix(game_dir)
+            .map(|path| path.to_owned())
+            .unwrap_or(path)
+    });
 
-    for (path, _) in paths.into_iter().rev() {
-        let mut path = path
-            .strip_prefix(game_dir)
-            .map(|path| path.into())
-            .unwrap_or(path);
+    queue_for_playing(marker, paths);
+}
 
+fn demos_in_folder(dir: &Path) -> Result<impl Iterator<Item = PathBuf>, String> {
+    let files = dir
+        .read_dir()
+        .map_err(|_| format!("could not open directory {}", dir.to_string_lossy()))?;
+    Ok(files
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().map(|ext| ext == "dem").unwrap_or(false)))
+}
+
+fn run_demos_by_number(prefix: &Path) -> Result<impl DoubleEndedIterator<Item = PathBuf>, String> {
+    let name_prefix = match prefix.file_name() {
+        Some(prefix) => {
+            format!(
+                "{}_",
+                prefix
+                    .to_str()
+                    .ok_or_else(|| "the name contains invalid characters".to_string())?
+            )
+        }
+        None => "".into(),
+    };
+
+    let dir = prefix.parent().unwrap();
+    let mut demos: Vec<_> = demos_in_folder(dir)?
+        .filter_map(|path| {
+            path.file_stem()
+                .and_then(OsStr::to_str)
+                .filter(|name| name.starts_with(&name_prefix))
+                .and_then(|name| name[name_prefix.len()..].parse::<usize>().ok())
+                .map(|number| (path, number))
+        })
+        .collect();
+
+    demos.sort_unstable_by_key(|(_, number)| *number);
+
+    Ok(demos.into_iter().map(|(path, _)| path))
+}
+
+fn demos_alphabetically(dir: &Path) -> Result<impl DoubleEndedIterator<Item = PathBuf>, String> {
+    let mut demos: Vec<PathBuf> = demos_in_folder(dir)?.collect();
+    demos.sort_unstable();
+    Ok(demos.into_iter())
+}
+
+pub fn queue_for_playing(
+    marker: MainThreadMarker,
+    paths: impl DoubleEndedIterator<Item = PathBuf>,
+) {
+    let mut demos = DEMOS.borrow_mut(marker);
+
+    for mut path in paths.rev() {
         // find_demos() already returns files with .dem extensions. We can strip them, but only if
         // there's no second extension: in that case, playdemo won't append .dem for us.
         if Path::new(path.file_stem().unwrap()).extension().is_none() {
@@ -96,7 +167,7 @@ fn play_run(marker: MainThreadMarker, prefix: PathBuf) {
         if demo.len() >= 16 {
             con_print(
                 marker,
-                &format!("Error: filename {} is longer than 15 characters.\n", demo),
+                &format!("Error: filename {demo} is longer than 15 characters.\n"),
             );
             return;
         }
@@ -106,46 +177,17 @@ fn play_run(marker: MainThreadMarker, prefix: PathBuf) {
         demos.push(demo);
     }
 
+    if demos.is_empty() {
+        con_print(marker, "Error: no demos found.\n");
+        return;
+    }
+
     con_print(marker, &format!("Playing {} demos.\n", demos.len()));
 
     drop(demos);
     set_next_demo(marker);
 
     prepend_command(marker, "demos\n");
-}
-
-fn find_demos(prefix: PathBuf) -> Result<Vec<(PathBuf, usize)>, String> {
-    let name_prefix = match prefix.file_name() {
-        Some(prefix) => {
-            format!(
-                "{}_",
-                prefix
-                    .to_str()
-                    .ok_or_else(|| "the name contains invalid characters".to_string())?
-            )
-        }
-        None => "".into(),
-    };
-
-    let dir = prefix.parent().unwrap();
-    let mut demos: Vec<_> = dir
-        .read_dir()
-        .map_err(|_| format!("could not open directory {}", dir.to_string_lossy()))?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().map(|ext| ext == "dem").unwrap_or(false))
-        .filter_map(|path| {
-            path.file_stem()
-                .and_then(OsStr::to_str)
-                .filter(|name| name.starts_with(&name_prefix))
-                .and_then(|name| name[name_prefix.len()..].parse::<usize>().ok())
-                .map(|number| (path, number))
-        })
-        .collect();
-
-    demos.sort_unstable_by_key(|(_, number)| *number);
-
-    Ok(demos)
 }
 
 pub fn set_next_demo(marker: MainThreadMarker) {


### PR DESCRIPTION
"wildcard" is not really wildcard as it won't attempt to match things like what it should, more meant for folder.

`enumerate()` pretty much does nothing but I think it is better to keep it there to log something for the tuple.