### PR TITLE
capture: Add _bxt_cap_skip_non_gameplay_frames

### DIFF
--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -2199,7 +2199,7 @@ pub mod exported {
             };
 
             if rv != 0 {
-                if !capture_skip_non_gameplay::should_skip_non_gameplay_frames(marker) {
+                if capture_skip_non_gameplay::should_record_current_frame(marker) {
                     capture::time_passed(marker);
                 }
 

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -145,6 +145,10 @@ pub static ClientDLL_DrawTransparentTriangles: Pointer<unsafe extern "C" fn()> =
         null_mut(),
     );
 pub static cl: Pointer<*mut client_state_t> = Pointer::empty(b"cl\0");
+pub static cl_stats: Pointer<*mut [i32; 32]> = Pointer::empty(
+    // Not a real symbol name.
+    b"cl_stats\0",
+);
 pub static cl_viewent: Pointer<*mut cl_entity_s> = Pointer::empty(
     // Not a real symbol name.
     b"cl_viewent\0",
@@ -154,6 +158,10 @@ pub static cl_viewent_viewmodel: Pointer<*mut cl_entity_s_viewmodel> = Pointer::
     b"cl_viewent_viewmodel\0",
 );
 pub static cls: Pointer<*mut client_static_s> = Pointer::empty(b"cls\0");
+pub static cls_demoframecount: Pointer<*mut c_int> = Pointer::empty(
+    // Not a real symbol name.
+    b"cls_demoframecount\0",
+);
 pub static cls_demos: Pointer<*mut client_static_s_demos> = Pointer::empty(
     // Not a real symbol name.
     b"cls_demos\0",
@@ -878,9 +886,11 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &ClientDLL_Init,
     &ClientDLL_DrawTransparentTriangles,
     &cl,
+    &cl_stats,
     &cl_viewent,
     &cl_viewent_viewmodel,
     &cls,
+    &cls_demoframecount,
     &cls_demos,
     &Cmd_AddMallocCommand,
     &Cmd_Argc,
@@ -1341,8 +1351,10 @@ unsafe fn find_pointers(marker: MainThreadMarker) {
         pointer.set(marker, ptr);
     }
 
+    cl_stats.set(marker, cl.offset(marker, 174892));
     cl_viewent.set(marker, cl.offset(marker, 1717500));
     cl_viewent_viewmodel.set(marker, cl_viewent.offset(marker, 2888));
+    cls_demoframecount.set(marker, cls.offset(marker, 16776));
     cls_demos.set(marker, cls.offset(marker, 15960));
     frametime_remainder.set(marker, CL_Move.by_offset(marker, 452));
     idum.set(marker, ran1.by_offset(marker, 2));
@@ -1407,6 +1419,13 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
     match ptr.pattern_index(marker) {
         // 6153
         Some(0) => frametime_remainder.set(marker, ptr.by_offset(marker, 451)),
+        _ => (),
+    }
+
+    let ptr = &CL_PlayDemo_f;
+    match ptr.pattern_index(marker) {
+        // 8684
+        Some(0) => cls_demoframecount.set(marker, ptr.by_offset(marker, 735)),
         _ => (),
     }
 
@@ -1601,6 +1620,15 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
                 ptr.by_offset(marker, 395)
                     .and_then(|ptr| NonNull::new(ptr.as_ptr().sub(68))),
             );
+        }
+        _ => (),
+    }
+
+    let ptr = &R_DrawViewModel;
+    match ptr.pattern_index(marker) {
+        // 8684
+        Some(0) => {
+            cl_stats.set(marker, ptr.by_offset(marker, 129));
         }
         _ => (),
     }
@@ -2171,7 +2199,9 @@ pub mod exported {
             };
 
             if rv != 0 {
-                capture::time_passed(marker);
+                if !capture_skip_non_gameplay::should_skip_non_gameplay_frames(marker) {
+                    capture::time_passed(marker);
+                }
 
                 tas_optimizer::update_client_connection_condition(marker);
                 tas_optimizer::maybe_receive_messages_from_remote_server(marker);
@@ -2188,6 +2218,8 @@ pub mod exported {
     pub unsafe extern "C" fn my_CL_Disconnect() {
         abort_on_panic(move || {
             let marker = MainThreadMarker::new();
+
+            capture_skip_non_gameplay::on_cl_disconnect(marker);
 
             if !capture_video_per_demo::on_cl_disconnect(marker) {
                 capture::on_cl_disconnect(marker);

--- a/src/modules/capture_skip_non_gameplay.rs
+++ b/src/modules/capture_skip_non_gameplay.rs
@@ -1,0 +1,87 @@
+//! bxt_cap_skip_non_gameplay_frames.
+
+use super::cvars::CVar;
+use super::{capture, Module};
+use crate::hooks::engine;
+use crate::utils::*;
+
+pub struct CaptureSkipNonGameplay;
+impl Module for CaptureSkipNonGameplay {
+    fn name(&self) -> &'static str {
+        "Video capture (skips non-gameplay frames)"
+    }
+
+    fn description(&self) -> &'static str {
+        "Skipping loading frames or non-functional frames."
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        capture::Capture.is_enabled(marker)
+            && engine::cls.is_set(marker)
+            && engine::cl_stats.is_set(marker)
+            && engine::cls_demoframecount.is_set(marker)
+            && engine::cls_demos.is_set(marker)
+    }
+
+    fn cvars(&self) -> &'static [&'static super::cvars::CVar] {
+        static CVARS: &[&CVar] = &[&BXT_CAP_SKIP_NON_GAMEPLAY_FRAMES];
+        CVARS
+    }
+}
+
+static BXT_CAP_SKIP_NON_GAMEPLAY_FRAMES: CVar = CVar::new(
+    b"bxt_cap_skip_non_gameplay_frames\0",
+    b"0\0",
+    "\
+Skipping recording non-gameplay frames such as main menu, loading screen, or demo load.
+Set to `0` to disable. Set to `1` to enable. Default is `2`. \
+Any values higher than `1` will be the extra 'gameplay' frames being skipped. \
+For example, `2` means ''1'' extra gameplay frame skipped during capture.",
+);
+
+static FRAMES_SKIPPED: MainThreadCell<u32> = MainThreadCell::new(0);
+
+pub unsafe fn should_skip_non_gameplay_frames(marker: MainThreadMarker) -> bool {
+    if !CaptureSkipNonGameplay.is_enabled(marker) {
+        return false;
+    }
+
+    let skip_frames = BXT_CAP_SKIP_NON_GAMEPLAY_FRAMES.as_u64(marker);
+
+    if skip_frames == 0 {
+        return false;
+    }
+
+    if (&*engine::cls.get(marker)).state != 5 {
+        // If state is not 5, skip frame.
+        // State 4 is still loading.
+        return true;
+    }
+
+    // demoplayback is updated to 1 after state 4 is done.
+    // The current implementation will skip all the frames until some viewmodel values are set.
+    if (&*engine::cls_demos.get(marker)).demoplayback == 1 {
+        // For some reasons, the "true" first frame will be catched in this condition
+        // despite having no viewmodel shown in demo.
+        // So it does technically capture all non-loading frames.
+        if (*engine::cl_stats.get(marker))[2] == 0 {
+            // Fallback when there is no viewmodel assigned ever. Happens when no weapons are picked
+            // up. Frame 7 is guaranteed to be the "start" frame most of the time.
+            if *engine::cls_demoframecount.get(marker) < 7 {
+                return true;
+            }
+        }
+
+        // Alternative use of the cvar to skip multiple starting frames.
+        if FRAMES_SKIPPED.get(marker) + 1 < skip_frames as u32 {
+            FRAMES_SKIPPED.set(marker, FRAMES_SKIPPED.get(marker) + 1);
+            return true;
+        }
+    }
+
+    false
+}
+
+pub fn on_cl_disconnect(marker: MainThreadMarker) {
+    FRAMES_SKIPPED.set(marker, 0);
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -22,6 +22,7 @@ pub mod cvars;
 use cvars::CVar;
 
 pub mod capture;
+pub mod capture_skip_non_gameplay;
 pub mod capture_video_per_demo;
 pub mod comment_overflow_fix;
 pub mod demo_playback;
@@ -83,6 +84,7 @@ pub trait Module: Sync {
 /// All modules.
 pub static MODULES: &[&dyn Module] = &[
     &capture::Capture,
+    &capture_skip_non_gameplay::CaptureSkipNonGameplay,
     &capture_video_per_demo::CaptureVideoPerDemo,
     &commands::Commands,
     &comment_overflow_fix::CommentOverflowFix,


### PR DESCRIPTION
Recording normally would have loading. Here is a recording with lots of segments.

https://user-images.githubusercontent.com/29143195/202879114-02ab1feb-d821-4f17-b2c9-b077560f6acc.mp4

Here is one without loading. 

https://user-images.githubusercontent.com/29143195/202879124-a0059725-377b-4829-bdb7-0496491e3741.mp4

The `frame_count` could be changed around to omit early frames entirely. Though it might come at a cost of recording become janky. Some frames are broken as #2 mentions. That would need something else.

