### PR TITLE
Add bxt_cap_time_*

### DIFF
--- a/src/modules/capture/mod.rs
+++ b/src/modules/capture/mod.rs
@@ -475,6 +475,12 @@ pub unsafe fn on_host_filter_time(marker: MainThreadMarker) -> bool {
     }
 
     let time = recorder.time_for_current_frame();
+
+    if TIME.get(marker) < BXT_CAP_TIME_START.as_f32(marker) as f64 {
+        *engine::realtime.get(marker) += *engine::host_frametime.get(marker);
+        return true;
+    }
+
     *engine::host_frametime.get(marker) = time;
     *engine::realtime.get(marker) += time;
 


### PR DESCRIPTION
I was working with campath and sometimes I just want to capture a segment. Currently there is no way to scrub through demo quickly and this just seems to do the trick. Tested with normal and sampling capture.

Potentially, this could make resuming capture possible as well.