### PR TITLE
Add bxt_emit_sound

### DIFF
--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -727,6 +727,10 @@ pub static SCR_DrawLoading: Pointer<unsafe extern "C" fn()> = Pointer::empty_pat
 pub static scr_fov_value: Pointer<*mut c_float> = Pointer::empty(b"scr_fov_value\0");
 pub static shm: Pointer<*mut *mut dma_t> = Pointer::empty(b"shm\0");
 pub static sv: Pointer<*mut c_void> = Pointer::empty(b"sv\0");
+pub static sv_edicts: Pointer<*mut *mut edict_s> = Pointer::empty(
+    // Not a real symbol name.
+    b"sv_edicts\0",
+);
 pub static svs: Pointer<*mut server_static_s> = Pointer::empty(b"svs\0");
 pub static sv_areanodes: Pointer<*mut c_void> = Pointer::empty(b"sv_areanodes\0");
 pub static SV_AddLinksToPM: Pointer<unsafe extern "C" fn(*mut c_void, *const [f32; 3])> =
@@ -999,6 +1003,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &scr_fov_value,
     &shm,
     &sv,
+    &sv_edicts,
     &svs,
     &sv_areanodes,
     &SV_AddLinksToPM,
@@ -1421,6 +1426,7 @@ unsafe fn find_pointers(marker: MainThreadMarker) {
     ran1_iy.set(marker, ran1.by_offset(marker, 13));
     ran1_iv.set(marker, ran1.by_offset(marker, 116));
     client_s_edict_offset.set(marker, Some(19076));
+    sv_edicts.set(marker, sv.offset(marker, 244824));
 
     for pointer in POINTERS {
         pointer.log(marker);
@@ -1611,12 +1617,14 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
         // 6153
         Some(0) => {
             sv.set(marker, ptr.by_offset(marker, 19));
+            sv_edicts.set(marker, sv.offset(marker, 0x3bc60));
             cls.set(marker, ptr.by_offset(marker, 69));
             Con_Printf.set_if_empty(marker, ptr.by_relative_call(marker, 33));
         }
         // CoF-5936
         Some(1) => {
             sv.set(marker, ptr.by_offset(marker, 50));
+            sv_edicts.set(marker, sv.offset(marker, 0x52160));
             cls.set(marker, ptr.by_offset(marker, 105));
             Con_Printf.set_if_empty(marker, ptr.by_relative_call(marker, 34));
         }

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -731,6 +731,10 @@ pub static sv_edicts: Pointer<*mut *mut edict_s> = Pointer::empty(
     // Not a real symbol name.
     b"sv_edicts\0",
 );
+pub static sv_num_edicts: Pointer<*mut c_int> = Pointer::empty(
+    // Not a real symbol name.
+    b"sv_num_edicts\0",
+);
 pub static svs: Pointer<*mut server_static_s> = Pointer::empty(b"svs\0");
 pub static sv_areanodes: Pointer<*mut c_void> = Pointer::empty(b"sv_areanodes\0");
 pub static SV_AddLinksToPM: Pointer<unsafe extern "C" fn(*mut c_void, *const [f32; 3])> =
@@ -1004,6 +1008,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &shm,
     &sv,
     &sv_edicts,
+    &sv_num_edicts,
     &svs,
     &sv_areanodes,
     &SV_AddLinksToPM,
@@ -1427,6 +1432,7 @@ unsafe fn find_pointers(marker: MainThreadMarker) {
     ran1_iv.set(marker, ran1.by_offset(marker, 116));
     client_s_edict_offset.set(marker, Some(19076));
     sv_edicts.set(marker, sv.offset(marker, 244824));
+    sv_num_edicts.set(marker, sv.offset(marker, 0x3bc50));
 
     for pointer in POINTERS {
         pointer.log(marker);
@@ -1618,6 +1624,7 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
         Some(0) => {
             sv.set(marker, ptr.by_offset(marker, 19));
             sv_edicts.set(marker, sv.offset(marker, 0x3bc60));
+            sv_num_edicts.set(marker, sv.offset(marker, 0x3bc58));
             cls.set(marker, ptr.by_offset(marker, 69));
             Con_Printf.set_if_empty(marker, ptr.by_relative_call(marker, 33));
         }
@@ -1625,6 +1632,7 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
         Some(1) => {
             sv.set(marker, ptr.by_offset(marker, 50));
             sv_edicts.set(marker, sv.offset(marker, 0x52160));
+            sv_num_edicts.set(marker, sv.offset(marker, 0x52158));
             cls.set(marker, ptr.by_offset(marker, 105));
             Con_Printf.set_if_empty(marker, ptr.by_relative_call(marker, 34));
         }

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -640,6 +640,8 @@ pub static S_PaintChannels: Pointer<unsafe extern "C" fn(c_int)> = Pointer::empt
     ]),
     my_S_PaintChannels as _,
 );
+pub static S_PrecacheSound: Pointer<unsafe extern "C" fn(*const c_char) -> *mut c_void> =
+    Pointer::empty_patterns(b"S_PrecacheSound\0", Patterns(&[]), null_mut());
 pub static S_TransferStereo16: Pointer<unsafe extern "C" fn(c_int)> = Pointer::empty_patterns(
     b"S_TransferStereo16\0",
     // To find, find S_PaintChannels(), go into the last call before the while () condition in the
@@ -742,6 +744,9 @@ pub static SV_RunCmd: Pointer<unsafe extern "C" fn(*mut usercmd_s, c_int)> =
         ]),
         null_mut(),
     );
+pub static SV_StartSound: Pointer<
+    unsafe extern "C" fn(c_int, *mut edict_s, c_int, *const c_char, c_int, c_float, c_int, c_int),
+> = Pointer::empty_patterns(b"SV_StartSound\0", Patterns(&[]), null_mut());
 pub static Sys_VID_FlipScreen: Pointer<unsafe extern "C" fn()> = Pointer::empty_patterns(
     b"_Z18Sys_VID_FlipScreenv\0",
     // To find, search for "Sys_InitLauncherInterface()". Go into function right after the one that
@@ -931,6 +936,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &R_LoadSkys,
     &R_PreDrawViewModel,
     &S_PaintChannels,
+    &S_PrecacheSound,
     &S_TransferStereo16,
     &SCR_DrawLoading,
     &scr_fov_value,
@@ -943,6 +949,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &SV_ExecuteClientMessage,
     &SV_Frame,
     &SV_RunCmd,
+    &SV_StartSound,
     &Sys_VID_FlipScreen,
     &Sys_VID_FlipScreen_old,
     &tri,

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -640,8 +640,13 @@ pub static S_PaintChannels: Pointer<unsafe extern "C" fn(c_int)> = Pointer::empt
     ]),
     my_S_PaintChannels as _,
 );
-pub static S_PrecacheSound: Pointer<unsafe extern "C" fn(*const c_char) -> *mut c_void> =
+pub static S_PrecacheSound: Pointer<unsafe extern "C" fn(*const c_char) -> *mut sfx_s> =
     Pointer::empty_patterns(b"S_PrecacheSound\0", Patterns(&[]), null_mut());
+pub static S_StartDynamicSound: Pointer<
+    unsafe extern "C" fn(c_int, c_int, *mut sfx_s, *const c_float, c_float, c_float, c_int, c_int),
+> = Pointer::empty_patterns(b"S_StartDynamicSound\0", Patterns(&[]), null_mut());
+pub static S_StopSound: Pointer<unsafe extern "C" fn(c_int, c_int)> =
+    Pointer::empty_patterns(b"S_StopSound\0", Patterns(&[]), null_mut());
 pub static S_TransferStereo16: Pointer<unsafe extern "C" fn(c_int)> = Pointer::empty_patterns(
     b"S_TransferStereo16\0",
     // To find, find S_PaintChannels(), go into the last call before the while () condition in the
@@ -744,9 +749,6 @@ pub static SV_RunCmd: Pointer<unsafe extern "C" fn(*mut usercmd_s, c_int)> =
         ]),
         null_mut(),
     );
-pub static SV_StartSound: Pointer<
-    unsafe extern "C" fn(c_int, *mut edict_s, c_int, *const c_char, c_int, c_float, c_int, c_int),
-> = Pointer::empty_patterns(b"SV_StartSound\0", Patterns(&[]), null_mut());
 pub static Sys_VID_FlipScreen: Pointer<unsafe extern "C" fn()> = Pointer::empty_patterns(
     b"_Z18Sys_VID_FlipScreenv\0",
     // To find, search for "Sys_InitLauncherInterface()". Go into function right after the one that
@@ -937,6 +939,8 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &R_PreDrawViewModel,
     &S_PaintChannels,
     &S_PrecacheSound,
+    &S_StartDynamicSound,
+    &S_StopSound,
     &S_TransferStereo16,
     &SCR_DrawLoading,
     &scr_fov_value,
@@ -949,7 +953,6 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &SV_ExecuteClientMessage,
     &SV_Frame,
     &SV_RunCmd,
-    &SV_StartSound,
     &Sys_VID_FlipScreen,
     &Sys_VID_FlipScreen_old,
     &tri,
@@ -1162,6 +1165,14 @@ pub struct ref_params_s {
     pub spectator: c_int,
     pub onground: c_int,
     pub waterlevel: c_int,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct sfx_s {
+    pub name: [c_char; 64],
+    pub cache: *mut c_void,
+    pub servercount: c_int,
 }
 
 impl SCREENINFO {

--- a/src/modules/emit_sound.rs
+++ b/src/modules/emit_sound.rs
@@ -18,7 +18,7 @@ impl Module for EmitSound {
     }
 
     fn description(&self) -> &'static str {
-        "Exposing SV_StartSound to allow usage of other sound channels."
+        "Exposing some sound functions."
     }
 
     fn commands(&self) -> &'static [&'static Command] {
@@ -75,7 +75,7 @@ static BXT_EMIT_SOUND: Command = Command::new(
     handler!(
         "bxt_emit_sound <sound> <channel> [volume] [from] [to] [attenuation] [flag] [pitch]
 
-Plays sound file directly from SV_StartSound along with custom arguments.",
+Plays sound file directly from S_StartDynamicSound.",
         emit_sound as fn(_, _, _),
         emit_sound_full as fn(_, _)
     ),

--- a/src/modules/emit_sound.rs
+++ b/src/modules/emit_sound.rs
@@ -1,0 +1,126 @@
+//! `bxt_emit_sound`
+
+use std::ffi::CString;
+use std::num::ParseFloatError;
+use std::ptr::NonNull;
+use std::str::FromStr;
+
+use super::Module;
+use crate::handler;
+use crate::hooks::engine;
+use crate::modules::commands::Command;
+use crate::utils::*;
+
+pub struct EmitSound;
+impl Module for EmitSound {
+    fn name(&self) -> &'static str {
+        "bxt_emit_sound"
+    }
+
+    fn description(&self) -> &'static str {
+        "Exposing SV_StartSound to allow usage of other sound channels."
+    }
+
+    fn commands(&self) -> &'static [&'static Command] {
+        static COMMANDS: &[&Command] = &[&BXT_EMIT_SOUND];
+        COMMANDS
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        engine::SV_StartSound.is_set(marker) && engine::S_PrecacheSound.is_set(marker)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+struct SoundInfo {
+    sound: String,
+    channel: i32,
+    volume: i32,
+    entity_index: u32,
+    recipent: i32,
+    attenuation: f32,
+    flag: i32,
+    pitch: i32,
+}
+
+// Eh.
+// Parse float then round then convert to integer to avoid a more convoluted solution.
+impl FromStr for SoundInfo {
+    type Err = ParseFloatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut rv = SoundInfo::default();
+
+        let mut iter = s.split_ascii_whitespace();
+        rv.sound = iter.next().unwrap_or_default().to_string();
+        rv.channel = (f32::from_str(iter.next().unwrap_or_default())?).round() as i32;
+        rv.volume = (f32::from_str(iter.next().unwrap_or_default())?).round() as i32;
+        rv.entity_index = (f32::from_str(iter.next().unwrap_or_default())?).round() as u32;
+        rv.recipent = (f32::from_str(iter.next().unwrap_or_default())?).round() as i32;
+        rv.attenuation = f32::from_str(iter.next().unwrap_or_default())?;
+        rv.flag = (f32::from_str(iter.next().unwrap_or_default())?).round() as i32;
+        rv.pitch = (f32::from_str(iter.next().unwrap_or_default())?).round() as i32;
+
+        Ok(rv)
+    }
+}
+
+static BXT_EMIT_SOUND: Command = Command::new(
+    b"bxt_emit_sound\0",
+    handler!(
+        "bxt_emit_sound <sound> <channel> [volume] [entity index] [recipent] [attenuation] [flag] [pitch]
+Plays sound file directly from SV_StartSound along with custom arguments.",
+        play_sound as fn(_, _, _),
+        play_sound_with_volume as fn(_, _, _, _),
+        play_sound_full as fn(_, _)
+    ),
+);
+
+fn play_sound(marker: MainThreadMarker, sound: String, channel: i32) {
+    play_sound_with_volume(marker, sound, channel, 255);
+}
+
+fn play_sound_with_volume(marker: MainThreadMarker, sound: String, channel: i32, volume: i32) {
+    play_sound_full(
+        marker,
+        SoundInfo {
+            sound,
+            channel,
+            volume,
+            entity_index: 0,
+            recipent: 0,
+            attenuation: 0.8,
+            flag: 0,
+            pitch: 100,
+        },
+    );
+}
+
+fn play_sound_full(marker: MainThreadMarker, info: SoundInfo) {
+    if let Some(player) = unsafe { engine::player_edict(marker) } {
+        // Player is usually index 0, from there just goes up.
+        // bxt_emit_sound "common/bodysplat.wav 0 255 0 0 0.8 0 100"
+        let mut entity =
+            unsafe { NonNull::new(player.as_ptr().add(info.entity_index as usize)).unwrap() };
+
+        let entity = unsafe { entity.as_mut() };
+        let binding = CString::new(info.sound).unwrap();
+        let sound = binding.as_ptr();
+
+        unsafe {
+            // Need to precache so it can play.
+            engine::S_PrecacheSound.get(marker)(sound);
+
+            engine::SV_StartSound.get(marker)(
+                info.recipent,
+                entity,
+                info.channel,
+                sound,
+                info.volume,
+                info.attenuation,
+                info.flag,
+                info.pitch,
+            );
+        };
+    }
+}

--- a/src/modules/emit_sound.rs
+++ b/src/modules/emit_sound.rs
@@ -22,12 +22,17 @@ impl Module for EmitSound {
     }
 
     fn commands(&self) -> &'static [&'static Command] {
-        static COMMANDS: &[&Command] = &[&BXT_EMIT_SOUND_STOP_SOUND_EXCEPT, &BXT_EMIT_SOUND];
+        static COMMANDS: &[&Command] = &[
+            &BXT_EMIT_SOUND_STOP_SOUND_EXCEPT,
+            &BXT_EMIT_SOUND_DYNAMIC,
+            &BXT_EMIT_SOUND,
+        ];
         COMMANDS
     }
 
     fn is_enabled(&self, marker: MainThreadMarker) -> bool {
-        engine::S_StartDynamicSound.is_set(marker)
+        engine::SV_StartSound.is_set(marker)
+            && engine::S_StartDynamicSound.is_set(marker)
             && engine::S_StopSound.is_set(marker)
             && engine::S_PrecacheSound.is_set(marker)
     }
@@ -41,11 +46,28 @@ struct SoundInfo {
     volume: f32,
     from: i32,
     to: i32,
-    /// "NORM" is 0.8
+    /// This is the "radius" of the sound. Close to 1, you hear sound quieter when moving farther
+    /// from entity. "NORM" for sound-emitting entity is 0.8.
+    /// 0 is not quite to make it "global". Negative value will do.
     attenuation: f32,
     flag: i32,
     /// 100 is no shift.
     pitch: i32,
+}
+
+impl SoundInfo {
+    fn new(sound: String, channel: i32) -> Self {
+        SoundInfo {
+            sound,
+            channel,
+            volume: 1.,
+            from: 0,
+            to: 0,
+            attenuation: 0.,
+            flag: 0,
+            pitch: 100,
+        }
+    }
 }
 
 // Eh.
@@ -74,34 +96,69 @@ static BXT_EMIT_SOUND: Command = Command::new(
     b"bxt_emit_sound\0",
     handler!(
         "bxt_emit_sound <sound> <channel> [volume] [from] [to] [attenuation] [flag] [pitch]
-
-Plays sound file directly from S_StartDynamicSound.",
+Plays sound file directly from SV_StartSound.",
         emit_sound as fn(_, _, _),
         emit_sound_full as fn(_, _)
     ),
 );
 
 fn emit_sound(marker: MainThreadMarker, sound: String, channel: i32) {
-    emit_sound_full(
-        marker,
-        SoundInfo {
-            sound,
-            channel,
-            volume: 1.,
-            from: 0,
-            to: 0,
-            attenuation: 0.8,
-            flag: 0,
-            pitch: 100,
-        },
-    )
+    emit_sound_full(marker, SoundInfo::new(sound, channel));
 }
 
 fn emit_sound_full(marker: MainThreadMarker, info: SoundInfo) {
     if let Some(player) = unsafe { engine::player_edict(marker) } {
-        // TODO: mimic S_StartDynamicSound fully so sounds played from player will follow.
-        let to = unsafe { NonNull::new(player.as_ptr().add(info.to as usize)).unwrap() };
-        let origin = unsafe { to.as_ref() }.v.origin;
+        let mut entity = unsafe { NonNull::new(player.as_ptr().add(info.from as usize)).unwrap() };
+
+        let entity = unsafe { entity.as_mut() };
+        let binding = CString::new(info.sound).unwrap();
+        let sound = binding.as_ptr();
+
+        unsafe {
+            // TODO: precache the sound so it can play any sound like dynamic option.
+            engine::S_PrecacheSound.get(marker)(sound);
+
+            engine::SV_StartSound.get(marker)(
+                info.to,
+                entity,
+                info.channel,
+                sound,
+                // [0,255]
+                (info.volume * 255.).round() as i32,
+                info.attenuation,
+                info.flag,
+                info.pitch,
+            );
+        };
+    }
+}
+
+static BXT_EMIT_SOUND_DYNAMIC: Command = Command::new(
+    b"bxt_emit_sound_dynamic\0",
+    handler!(
+        "bxt_emit_sound_dynamic <sound> <channel> [volume] [from] [to] [attenuation] [flag] [pitch]
+
+Plays sound file directly from S_StartDynamicSound.",
+        emit_sound_dynamic as fn(_, _, _),
+        emit_sound_dynamic_full as fn(_, _)
+    ),
+);
+
+fn emit_sound_dynamic(marker: MainThreadMarker, sound: String, channel: i32) {
+    emit_sound_dynamic_full(marker, SoundInfo::new(sound, channel))
+}
+
+fn emit_sound_dynamic_full(marker: MainThreadMarker, info: SoundInfo) {
+    if let Some(player) = unsafe { engine::player_edict(marker) } {
+        let origin = unsafe {
+            if info.to == 0 {
+                // It does this to have the sound follow player's vieworg rather than origin.
+                *engine::listener_origin.get(marker)
+            } else {
+                let to = NonNull::new(player.as_ptr().add(info.to as usize)).unwrap();
+                to.as_ref().v.origin
+            }
+        };
 
         let binding = CString::new(info.sound).unwrap();
         let sound = binding.as_ptr();
@@ -127,16 +184,19 @@ static BXT_EMIT_SOUND_STOP_SOUND_EXCEPT: Command = Command::new(
     handler!(
         "bxt_emit_sound_stop_sound_except <list of channels seperated by space>.
         
-Stops emitting sounds from every channel except for given list of channels.",
+Stops emitting sounds from every channel except given list of channels.",
         stop_sound as fn(_, _)
     ),
 );
 
+// It goes up to 14-15 something. I've seen up to 8 used so far.
+static MAX_CHANNELS: i32 = 10;
+
 fn stop_sound(marker: MainThreadMarker, channels: String) {
-    let mut list: Vec<i32> = Vec::new();
+    let mut list = vec![];
     // There should be only 8 usable channels from SV_StartSounds.
     // But SND_PickDynamicChannel says something very weird otherwise.
-    let mut list0: Vec<i32> = vec![0, 1, 2, 3, 4, 5, 6, 7];
+    let mut list0 = Vec::from_iter(0..MAX_CHANNELS + 1);
     let iter = channels.split_ascii_whitespace();
 
     for channel in iter {
@@ -149,8 +209,7 @@ fn stop_sound(marker: MainThreadMarker, channels: String) {
     list.sort();
 
     for channel in list.iter().rev() {
-        let channel = (*channel).clamp(0i32, 7i32);
-
+        let channel = (*channel).clamp(0i32, MAX_CHANNELS);
         list0.remove(channel as usize);
     }
 

--- a/src/modules/emit_sound.rs
+++ b/src/modules/emit_sound.rs
@@ -149,7 +149,9 @@ fn stop_sound(marker: MainThreadMarker, channels: String) {
     list.sort();
 
     for channel in list.iter().rev() {
-        list0.remove(*channel as usize);
+        let channel = (*channel).clamp(0i32, 7i32);
+
+        list0.remove(channel as usize);
     }
 
     for channel in list0 {

--- a/src/modules/emit_sound.rs
+++ b/src/modules/emit_sound.rs
@@ -37,6 +37,7 @@ impl Module for EmitSound {
             && engine::S_PrecacheSound.is_set(marker)
             && engine::listener_origin.is_set(marker)
             && engine::sv_edicts.is_set(marker)
+            && engine::sv_num_edicts.is_set(marker)
     }
 }
 
@@ -178,7 +179,7 @@ fn emit_sound_dynamic_full(marker: MainThreadMarker, info: SoundInfo) {
             // It does this to have the sound follow player's vieworg rather than origin.
             *engine::listener_origin.get(marker)
         } else {
-            if info.from >= *engine::sv_num_edicts.get(marker) {
+            if info.to >= *engine::sv_num_edicts.get(marker) {
                 return;
             }
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -26,6 +26,7 @@ pub mod capture_video_per_demo;
 pub mod comment_overflow_fix;
 pub mod demo_playback;
 pub mod disable_loading_text;
+pub mod emit_sound;
 pub mod fade_remove;
 pub mod force_fov;
 pub mod help;
@@ -89,6 +90,7 @@ pub static MODULES: &[&dyn Module] = &[
     &cvars::CVars,
     &demo_playback::DemoPlayback,
     &disable_loading_text::DisableLoadingText,
+    &emit_sound::EmitSound,
     &fade_remove::FadeRemove,
     &force_fov::ForceFov,
     &help::Help,


### PR DESCRIPTION
Edit: S_StartDynamicSound might be not what I want. It doesn't work per channel as I thought it would. The reason why I changed to S_StartDynamicSound is to avoid doing extra precache mechanism so any sounds can be played. I think I might need to revert two recent changes and then figure out how to do precache (or maybe not).

Edit 2: Never mind, it is good. I am just hallucinating.

Edit 3: After some more playing around, I think I have to make it similar to `speak` where it emits from where the player view is, rather than player origin. Big TODO in there and I thought it wouldn't come back.

Final edit: This should be good. I learn that the issue I've been having is just misusing the attenuation value. So now there are two options to emit sound with two different commands. Though for normal `bxt_emit_sound`, precaching might be a bit complicated for me for now to figure out how to do it properly. Meanwhile, `bxt_emit_sound_dynamic` can do that just fine. The difference between the two beside ability to play any sound is probably a jungle of sphagetti behind those twos. `bxt_emit_sound` will simply just work while `bxt_emit_sound_dynamic` might weirdly do something to other channels unless we pick correct channel.