### PR TITLE
Port bxt_fix_widescreen_fov

### DIFF
--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -2178,6 +2178,8 @@ pub mod exported {
                 *scr_fov_value.get(marker) = fov;
             }
 
+            fix_widescreen::fix_widescreen_fov(marker);
+
             R_SetFrustum.get(marker)();
         })
     }

--- a/src/modules/fix_widescreen.rs
+++ b/src/modules/fix_widescreen.rs
@@ -1,0 +1,70 @@
+//! `bxt_fix_widescreen_fov`
+
+use super::Module;
+use crate::hooks::engine;
+use crate::modules::cvars::CVar;
+use crate::utils::*;
+
+pub struct FixWidescreen;
+impl Module for FixWidescreen {
+    fn name(&self) -> &'static str {
+        "bxt_fix_widescreen_fov"
+    }
+
+    fn description(&self) -> &'static str {
+        "Fixes widescreen vertical field-of-view."
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        engine::R_SetFrustum.is_set(marker) && engine::scr_fov_value.is_set(marker)
+    }
+
+    fn cvars(&self) -> &'static [&'static CVar] {
+        static CVARS: &[&CVar] = &[&BXT_FIX_WIDESCREEN_FOV];
+        CVARS
+    }
+}
+
+static BXT_FIX_WIDESCREEN_FOV: CVar = CVar::new(
+    b"bxt_fix_widescreen_fov\0",
+    b"0\0",
+    "\
+Fixes reduction in vertical field-of-view of widescreen. Compatible with `bxt_force_fov`",
+);
+
+// My guess is that every render cycle, `scr_fov_value` is reset to some values.
+// So even if we override it, at some points, it is back to something else entirely different.
+// But that is not the case for loading. If we don't do this, we will doubly process the value.
+static PREV_FOV: MainThreadRefCell<f32> = MainThreadRefCell::new(0.);
+
+pub fn fix_widescreen_fov(marker: MainThreadMarker) {
+    if !FixWidescreen.is_enabled(marker) {
+        return;
+    }
+
+    if !BXT_FIX_WIDESCREEN_FOV.as_bool(marker) {
+        return;
+    }
+
+    let fov = unsafe { *engine::scr_fov_value.get(marker) };
+    let prev_fov = *PREV_FOV.borrow(marker);
+
+    if fov != prev_fov {
+        let (width, height) = unsafe { engine::get_resolution(marker) };
+        let current_aspect_ratio = width as f32 / height as f32;
+        let default_aspect_ratio = 3f32 / 4f32;
+
+        let new_fov =
+            (((fov.to_radians() / 2.).tan() * default_aspect_ratio * current_aspect_ratio)
+                .atan()
+                .to_degrees()
+                * 2.)
+                .clamp(10f32, 150f32);
+
+        unsafe {
+            *engine::scr_fov_value.get(marker) = new_fov;
+        }
+
+        *PREV_FOV.borrow_mut(marker) = new_fov;
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -27,6 +27,7 @@ pub mod comment_overflow_fix;
 pub mod demo_playback;
 pub mod disable_loading_text;
 pub mod fade_remove;
+pub mod fix_widescreen;
 pub mod force_fov;
 pub mod help;
 pub mod hud;
@@ -89,6 +90,7 @@ pub static MODULES: &[&dyn Module] = &[
     &demo_playback::DemoPlayback,
     &disable_loading_text::DisableLoadingText,
     &fade_remove::FadeRemove,
+    &fix_widescreen::FixWidescreen,
     &force_fov::ForceFov,
     &help::Help,
     &hud::Hud,


### PR DESCRIPTION
Port of https://github.com/YaLTeR/BunnymodXT/pull/448 with fix from https://github.com/YaLTeR/BunnymodXT/issues/451

I was thinking of doing the fix differently by restoring `scr_fov_value` after some functions are done using it (biggestly `R_RenderView`).

That might be or might be not necessary. Because this is a "fix", so it should not really write some info into the demo, I thought to myself. But I guess this would be just fine.