### PR TITLE
Add bxt_tas_studio_replay_views

### DIFF
--- a/bxt-strafe/src/lib.rs
+++ b/bxt-strafe/src/lib.rs
@@ -133,6 +133,8 @@ pub struct State {
     // Number of frames for [`StrafeDir::LeftRight`] or [`StrafeDir::RightLeft`] which goes from
     // `0` to `count - 1`.
     pub strafe_cycle_frame_count: u32,
+    // In case of yaw and pitch override, this might be useful.
+    pub rendered_viewangles: Vec3,
 }
 
 impl State {
@@ -145,6 +147,7 @@ impl State {
             jumped: false,
             move_traces: ArrayVec::new(),
             strafe_cycle_frame_count: 0,
+            rendered_viewangles: Vec3::ZERO,
         };
 
         rv.update_place(tracer);

--- a/src/hooks/bxt.rs
+++ b/src/hooks/bxt.rs
@@ -141,6 +141,7 @@ pub struct OnTasPlaybackFrameData {
     pub strafe_cycle_frame_count: u32,
     pub prev_predicted_trace_fractions: [f32; 4],
     pub prev_predicted_trace_normal_zs: [f32; 4],
+    pub rendered_viewangles: [f32; 3],
 }
 
 unsafe extern "C" fn on_tas_playback_frame(data: OnTasPlaybackFrameData) -> c_int {

--- a/src/modules/tas_studio/editor/mod.rs
+++ b/src/modules/tas_studio/editor/mod.rs
@@ -478,6 +478,18 @@ impl Editor {
         self.hovered_frame_idx.map(|idx| &self.branch().frames[idx])
     }
 
+    pub fn has_all_accurate_frames(&self) -> bool {
+        let frame_count = self
+            .branch()
+            .branch
+            .script
+            .frame_bulks()
+            .map(|bulk| bulk.frame_count.get() as usize)
+            .sum::<usize>();
+
+        self.branch().first_predicted_frame == frame_count + 1
+    }
+
     pub fn undo_log_len(&self) -> usize {
         self.undo_log.len()
     }
@@ -2814,16 +2826,8 @@ impl Editor {
             return Err(ManualOpError::CannotDoDuringAdjustment);
         }
 
-        let frame_count = self
-            .branch()
-            .branch
-            .script
-            .frame_bulks()
-            .map(|bulk| bulk.frame_count.get() as usize)
-            .sum::<usize>();
-
         // Only smooth when we have all accurate frames.
-        if self.branch().first_predicted_frame != frame_count + 1 {
+        if !self.has_all_accurate_frames() {
             return Err(ManualOpError::UserError(
                 "all frames must be accurate (simulated by the \
                  second game) to apply global smoothing"

--- a/src/modules/tas_studio/mod.rs
+++ b/src/modules/tas_studio/mod.rs
@@ -71,6 +71,7 @@ impl Module for TasStudio {
             &BXT_TAS_STUDIO_NEW,
             &BXT_TAS_STUDIO_LOAD,
             &BXT_TAS_STUDIO_CONVERT_HLTAS,
+            &BXT_TAS_STUDIO_REPLAY_VIEWS,
             &BXT_TAS_STUDIO_REPLAY,
             &BXT_TAS_STUDIO_SET_STOP_FRAME,
             &BXT_TAS_STUDIO_SET_YAWSPEED,
@@ -391,11 +392,13 @@ fn norefresh_until_stop_frame_frame_idx(marker: MainThreadMarker, editor: &Edito
     let norefresh_last_frames =
         unsafe { bxt::BXT_TAS_NOREFRESH_UNTIL_LAST_FRAMES.get(marker)() } as usize;
 
-    if editor.stop_frame() == 0 {
+    let first_frame_idx = if editor.stop_frame() == 0 {
         (editor.branch().frames.len() - 1).saturating_sub(norefresh_last_frames)
     } else {
         (editor.stop_frame() as usize).saturating_sub(norefresh_last_frames)
-    }
+    };
+
+    first_frame_idx.clamp(0, editor.branch().frames.len() - 1)
 }
 
 fn set_effective_norefresh_until_stop_frame(marker: MainThreadMarker, editor: &Editor) {
@@ -428,6 +431,71 @@ fn replay(marker: MainThreadMarker) {
         State::PlayingToEditor { editor, bridge, .. } => {
             set_effective_norefresh_until_stop_frame(marker, &editor);
             State::PreparingToPlayToEditor(editor, bridge, true)
+        }
+        other => other,
+    };
+}
+
+static BXT_TAS_STUDIO_REPLAY_VIEWS: Command = Command::new(
+    b"bxt_tas_studio_replay_views\0",
+    handler!(
+        "bxt_tas_studio_replay_views
+
+Replays the currently loaded camera views of TAS up to the stop frame.",
+        replay_views as fn(_)
+    ),
+);
+
+fn replay_views(marker: MainThreadMarker) {
+    let mut state = STATE.borrow_mut(marker);
+    *state = match mem::take(&mut *state) {
+        State::Editing {
+            mut editor,
+            last_generation,
+            last_branch_idx,
+            simulate_at,
+            bridge,
+        } => {
+            editor.cancel_ongoing_adjustments();
+
+            sdl::set_relative_mouse_mode(marker, true);
+            client::activate_mouse(marker, true);
+
+            // bxt_tas_norefresh_until_last_frames = 0 means 1 frame being played. Heh.
+            let start_frame = norefresh_until_stop_frame_frame_idx(marker, &editor);
+
+            engine::prepend_command(marker, "bxt_hud 0; hud_draw 0\n");
+
+            State::PlayingViews {
+                editor,
+                last_generation,
+                last_branch_idx,
+                simulate_at,
+                bridge,
+                current_frame: start_frame,
+            }
+        }
+        // Press play view again to stop.
+        State::PlayingViews {
+            editor,
+            last_generation,
+            last_branch_idx,
+            simulate_at,
+            bridge,
+            ..
+        } => {
+            sdl::set_relative_mouse_mode(marker, false);
+            client::activate_mouse(marker, false);
+            engine::prepend_command(marker, "bxt_hud 1; hud_draw 1\n");
+            ENABLE_FREECAM_ON_CALCREFDEF.set(marker, true);
+
+            State::Editing {
+                editor,
+                last_generation,
+                last_branch_idx,
+                simulate_at,
+                bridge,
+            }
         }
         other => other,
     };
@@ -1451,6 +1519,16 @@ enum State {
         simulate_at: Option<Instant>,
         bridge: Bridge,
     },
+    /// Playing camera views, will open the editor afterwards.
+    /// Playback is inside Editing mode so original data will be restored.
+    PlayingViews {
+        editor: Editor,
+        last_generation: u16,
+        last_branch_idx: usize,
+        simulate_at: Option<Instant>,
+        bridge: Bridge,
+        current_frame: usize,
+    },
 }
 
 impl Default for State {
@@ -1560,7 +1638,82 @@ pub unsafe fn maybe_receive_messages_from_remote_server(marker: MainThreadMarker
             editor.recompute_extra_camera_frame_data_if_needed();
         }
         State::PreparingToPlayToEditor(_, _, _) => unreachable!(),
+        _ => (),
     }
+}
+
+pub fn should_draw_pause(marker: MainThreadMarker) -> bool {
+    !matches!(*STATE.borrow_mut(marker), State::PlayingViews { .. })
+}
+
+pub fn tas_playback_rendered_views(marker: MainThreadMarker) {
+    if !TasStudio.is_enabled(marker) {
+        return;
+    }
+
+    let mut state = STATE.borrow_mut(marker);
+    *state = match mem::take(&mut *state) {
+        State::PlayingViews {
+            editor,
+            last_generation,
+            last_branch_idx,
+            simulate_at,
+            bridge,
+            current_frame,
+        } => {
+            if current_frame == editor.stop_frame() as usize
+                || current_frame >= editor.branch().frames.len()
+            {
+                sdl::set_relative_mouse_mode(marker, false);
+                client::activate_mouse(marker, false);
+                engine::prepend_command(marker, "bxt_hud 1; hud_draw 1\n");
+                ENABLE_FREECAM_ON_CALCREFDEF.set(marker, true);
+
+                State::Editing {
+                    editor,
+                    last_generation,
+                    last_branch_idx,
+                    simulate_at,
+                    bridge,
+                }
+            } else {
+                let r_refdef_vieworg = unsafe { &mut *engine::r_refdef_vieworg.get(marker) };
+                let r_refdef_viewangles = unsafe { &mut *engine::r_refdef_viewangles.get(marker) };
+
+                r_refdef_vieworg[0] = editor.branch().frames[current_frame].state.player.pos[0];
+                r_refdef_vieworg[1] = editor.branch().frames[current_frame].state.player.pos[1];
+                r_refdef_vieworg[2] = editor.branch().frames[current_frame].state.player.pos[2];
+
+                // We don't keep track of vieworg so just deduce it from here instead.
+                // It is not easy to keep track of vieworg because it isn't there to track.
+                // vieworg is calculated.
+                // It is also funny how vieworg is calculated here,
+                // but viewangles is passed from BXT.
+                r_refdef_vieworg[2] += 28.;
+                if editor.branch().frames[current_frame].state.player.ducking {
+                    r_refdef_vieworg[2] -= 16.;
+                }
+
+                r_refdef_viewangles[0] = editor.branch().frames[current_frame]
+                    .state
+                    .rendered_viewangles[0];
+
+                r_refdef_viewangles[1] = editor.branch().frames[current_frame]
+                    .state
+                    .rendered_viewangles[1];
+
+                State::PlayingViews {
+                    editor,
+                    last_generation,
+                    last_branch_idx,
+                    simulate_at,
+                    bridge,
+                    current_frame: current_frame + 1,
+                }
+            }
+        }
+        other => other,
+    };
 }
 
 pub unsafe fn on_tas_playback_frame(
@@ -1601,6 +1754,12 @@ pub unsafe fn on_tas_playback_frame(
             strafe_state.prev_frame_input.pitch = view_angles[0].to_radians();
             strafe_state.prev_frame_input.yaw = view_angles[1].to_radians();
         }
+
+        // Store the rendered viewangles
+        // Viewangles is always available. Same as origin.
+        // Vieworigin is something that is not available per player. It is calculated upon
+        // rendering.
+        strafe_state.rendered_viewangles = data.rendered_viewangles.into();
 
         // We don't have a good way to extract real trace results from the movement code, so let's
         // make up trace results based on previous frame's predicted fractions and normal Zs from

--- a/src/modules/tas_studio/mod.rs
+++ b/src/modules/tas_studio/mod.rs
@@ -456,23 +456,38 @@ fn replay_views(marker: MainThreadMarker) {
             simulate_at,
             bridge,
         } => {
-            editor.cancel_ongoing_adjustments();
+            if !editor.has_all_accurate_frames() {
+                con_print(
+                    marker,
+                    "You need to have second game done simulating to playback views.\n",
+                );
 
-            sdl::set_relative_mouse_mode(marker, true);
-            client::activate_mouse(marker, true);
+                State::Editing {
+                    editor,
+                    last_generation,
+                    last_branch_idx,
+                    simulate_at,
+                    bridge,
+                }
+            } else {
+                editor.cancel_ongoing_adjustments();
 
-            // bxt_tas_norefresh_until_last_frames = 0 means 1 frame being played. Heh.
-            let start_frame = norefresh_until_stop_frame_frame_idx(marker, &editor);
+                sdl::set_relative_mouse_mode(marker, true);
+                client::activate_mouse(marker, true);
 
-            engine::prepend_command(marker, "bxt_hud 0; hud_draw 0\n");
+                // bxt_tas_norefresh_until_last_frames = 0 means 1 frame being played. Heh.
+                let start_frame = norefresh_until_stop_frame_frame_idx(marker, &editor);
 
-            State::PlayingViews {
-                editor,
-                last_generation,
-                last_branch_idx,
-                simulate_at,
-                bridge,
-                current_frame: start_frame,
+                engine::prepend_command(marker, "bxt_hud 0; hud_draw 0\n");
+
+                State::PlayingViews {
+                    editor,
+                    last_generation,
+                    last_branch_idx,
+                    simulate_at,
+                    bridge,
+                    current_frame: start_frame,
+                }
             }
         }
         // Press play view again to stop.

--- a/src/modules/tas_studio/mod.rs
+++ b/src/modules/tas_studio/mod.rs
@@ -1656,7 +1656,12 @@ pub unsafe fn maybe_receive_messages_from_remote_server(marker: MainThreadMarker
             editor.recompute_extra_camera_frame_data_if_needed();
         }
         State::PreparingToPlayToEditor(_, _, _) => unreachable!(),
-        _ => (),
+        State::PlayingViews { .. } => {
+            // Do nothing
+            // While PlayingViews is happening, nothing else happens or will happen.
+            // Because PlayingViews only starts when all accurate frames are received.
+            // Meaning there is nothing second game could do anything to affect the state.
+        }
     }
 }
 


### PR DESCRIPTION
Closes #97 

Intended to work with yaw (and pitch) override and also without.

Seems pretty okay.

I don't want to figure out how to keep the same position after replay but if it is needed then I shall.

If no second game and no tas playback first time then viewangles replay won't work (not a problem and no one would encounter it but can be fixed very easy or not depending on the simulated run would override the values or not).

And
> bxt_tas_norefresh_until_last_frames = 0 means 1 frame being played. Heh.

If that needs changing then sure. I don't want to complicate all of the logic too much.
