### PR TITLE
Add Max Acceleration Yaw Offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ color-eyre = { version = "0.6.2", default-features = false }
 crossbeam-channel = "0.5.8"
 git-version = "0.3.5"
 glam = "0.24.1"
-hltas = { version = "0.8.0", features = ["serde1"] }
+hltas = { version = "0.9.0", features = ["serde1"] }
 ipc-channel = "0.16.1"
 itertools = "0.11.0"
 libc = "0.2.147"
@@ -51,7 +51,7 @@ features = ["libloaderapi", "psapi", "winuser", "synchapi", "handleapi", "proces
 
 [dev-dependencies]
 expect-test = "1.4.1"
-hltas = { version = "0.8.0", features = ["serde1", "proptest1"] }
+hltas = { version = "0.9.0", features = ["serde1", "proptest1"] }
 proptest = "1.2.0"
 
 [build-dependencies]

--- a/bxt-ipc-types/Cargo.toml
+++ b/bxt-ipc-types/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bxt-strafe = { version = "0.1.0", path = "../bxt-strafe" }
-hltas = { version = "0.8.0", features = ["serde1"] }
+hltas = { version = "0.9.0", features = ["serde1"] }
 serde = { version = "1.0.174", features = ["derive"] }

--- a/bxt-strafe/Cargo.toml
+++ b/bxt-strafe/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 arrayvec = { version = "0.7.4", features = ["serde"] }
 bxt-vct = { path = "../bxt-vct" }
 glam = { version = "0.24.1", features = ["serde"] }
-hltas = { version = "0.8.0" }
+hltas = { version = "0.9.0" }
 serde = { version = "1.0.174", features = ["derive"] }
 tap = "1.0.1"
 
@@ -15,4 +15,4 @@ tap = "1.0.1"
 ncollide3d = "0.33.0"
 proptest = "1.2.0"
 proptest-derive = "0.3.0"
-hltas = { version = "0.8.0", features = ["proptest1"] }
+hltas = { version = "0.9.0", features = ["proptest1"] }

--- a/bxt-strafe/src/lib.rs
+++ b/bxt-strafe/src/lib.rs
@@ -133,6 +133,13 @@ pub struct State {
     // Number of frames for [`StrafeDir::LeftRight`] or [`StrafeDir::RightLeft`] which goes from
     // `0` to `count - 1`.
     pub strafe_cycle_frame_count: u32,
+    // Accelerated yaw speed specifics
+    pub max_accel_yaw_offset_value: f32,
+    // These values are to indicate whether we are in a "different" frame bulk.
+    pub prev_max_accel_yaw_offset_start: f32,
+    pub prev_max_accel_yaw_offset_target: f32,
+    pub prev_max_accel_yaw_offset_accel: f32,
+    pub prev_max_accel_yaw_offset_right: bool,
     // In case of yaw and pitch override, this might be useful.
     pub rendered_viewangles: Vec3,
 }
@@ -147,6 +154,11 @@ impl State {
             jumped: false,
             move_traces: ArrayVec::new(),
             strafe_cycle_frame_count: 0,
+            max_accel_yaw_offset_value: 0.,
+            prev_max_accel_yaw_offset_start: 0.,
+            prev_max_accel_yaw_offset_target: 0.,
+            prev_max_accel_yaw_offset_accel: 0.,
+            prev_max_accel_yaw_offset_right: false,
             rendered_viewangles: Vec3::ZERO,
         };
 

--- a/src/hooks/bxt.rs
+++ b/src/hooks/bxt.rs
@@ -144,7 +144,18 @@ pub struct OnTasPlaybackFrameData {
     pub strafe_cycle_frame_count: u32,
     pub prev_predicted_trace_fractions: [f32; 4],
     pub prev_predicted_trace_normal_zs: [f32; 4],
+    pub max_accel_yaw_offset: OnTasPlaybackFrameMaxAccelYawOffset,
     pub rendered_viewangles: [f32; 3],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct OnTasPlaybackFrameMaxAccelYawOffset {
+    pub value: f32,
+    pub start: f32,
+    pub target: f32,
+    pub accel: f32,
+    pub dir: u8,
 }
 
 unsafe extern "C" fn on_tas_playback_frame(data: OnTasPlaybackFrameData) -> c_int {

--- a/src/hooks/bxt.rs
+++ b/src/hooks/bxt.rs
@@ -9,9 +9,9 @@ use hltas::HLTAS;
 use crate::modules::tas_studio;
 use crate::utils::{abort_on_panic, MainThreadMarker, Pointer, PointerTrait};
 
-pub static BXT_ON_TAS_PLAYBACK_FRAME: Pointer<
+pub static BXT_ON_TAS_PLAYBACK_FRAME_V2: Pointer<
     *mut Option<unsafe extern "C" fn(OnTasPlaybackFrameData) -> c_int>,
-> = Pointer::empty(b"bxt_on_tas_playback_frame\0");
+> = Pointer::empty(b"bxt_on_tas_playback_frame_v2\0");
 pub static BXT_ON_TAS_PLAYBACK_STOPPED: Pointer<*mut Option<unsafe extern "C" fn()>> =
     Pointer::empty(b"bxt_on_tas_playback_stopped\0");
 pub static BXT_SIMULATION_IPC_IS_CLIENT_INITIALIZED: Pointer<unsafe extern "C" fn() -> c_int> =
@@ -31,7 +31,7 @@ pub static BXT_TAS_STUDIO_FREECAM_SET_ORIGIN: Pointer<unsafe extern "C" fn([c_fl
     Pointer::empty(b"bxt_tas_studio_freecam_set_origin\0");
 
 static POINTERS: &[&dyn PointerTrait] = &[
-    &BXT_ON_TAS_PLAYBACK_FRAME,
+    &BXT_ON_TAS_PLAYBACK_FRAME_V2,
     &BXT_ON_TAS_PLAYBACK_STOPPED,
     &BXT_SIMULATION_IPC_IS_CLIENT_INITIALIZED,
     &BXT_TAS_LOAD_SCRIPT_FROM_STRING,
@@ -79,7 +79,7 @@ pub unsafe fn find_pointers(marker: MainThreadMarker) {
 }
 
 fn set_callbacks(marker: MainThreadMarker) {
-    if let Some(bxt_on_tas_playback_frame) = BXT_ON_TAS_PLAYBACK_FRAME.get_opt(marker) {
+    if let Some(bxt_on_tas_playback_frame) = BXT_ON_TAS_PLAYBACK_FRAME_V2.get_opt(marker) {
         // SAFETY: this is a global variable in BXT which is accessed only from the main game thread
         // (which is the current thread as we have a marker).
         unsafe {

--- a/src/modules/tas_studio/mod.rs
+++ b/src/modules/tas_studio/mod.rs
@@ -38,8 +38,7 @@ use crate::handler;
 use crate::hooks::bxt::{OnTasPlaybackFrameData, BXT_IS_TAS_EDITOR_ACTIVE};
 use crate::hooks::engine::con_print;
 use crate::hooks::{bxt, client, engine, sdl};
-use crate::modules::tas_studio::editor::MaxAccelYawOffsetMode;
-use crate::modules::tas_studio::editor::CameraViewAdjustmentMode;
+use crate::modules::tas_studio::editor::{CameraViewAdjustmentMode, MaxAccelYawOffsetMode};
 use crate::utils::*;
 
 pub struct TasStudio;
@@ -120,7 +119,7 @@ impl Module for TasStudio {
             && sdl::SDL_GetMouseState.is_set(marker)
             && bxt::BXT_TAS_LOAD_SCRIPT_FROM_STRING.is_set(marker)
             && bxt::BXT_IS_TAS_EDITOR_ACTIVE.is_set(marker)
-            && bxt::BXT_ON_TAS_PLAYBACK_FRAME.is_set(marker)
+            && bxt::BXT_ON_TAS_PLAYBACK_FRAME_V2.is_set(marker)
             && bxt::BXT_ON_TAS_PLAYBACK_STOPPED.is_set(marker)
             && bxt::BXT_TAS_NEW.is_set(marker)
             && bxt::BXT_TAS_NOREFRESH_UNTIL_LAST_FRAMES.is_set(marker)


### PR DESCRIPTION
Needs hltas update.

There are some things about this. First, I want that when a frame bulk of this type is split, it shouldn't reset the acceleration values. That is why the weird gymnastics is here. 

Second, I want it a bit easier to use so there's text popping up like #100 . I think it is pretty okay. I don't think the console command for this would be that necessary. 

No third point but I don't want to pass "accurate" data, specifically the current accumulated yawspeed, from BXT to bxt-rs because I think bxt-strafe won't ever mess it up.

I play around with it for a bit and it is very confusing to use. Might get some time getting used to because you have two parameters. I put some thoughts into the interactions and I think it works great for me. Not sure about others.

 