### PR TITLE
campath: add option to rotate camera points around origin Z axis

### DIFF
--- a/src/modules/campath/mod.rs
+++ b/src/modules/campath/mod.rs
@@ -78,7 +78,7 @@ static BXT_CAMPATH_ROTATE: CVar = CVar::new(
     b"bxt_campath_rotate\0",
     b"0\0",
     "\
-Rotates all camera points about origin by Z up axis by angle in degree.
+Rotates all camera points about the Z-up axis at the origin by this angle in degrees.
 
 HLAE CAM format is mainly for Source. But, Source horizontal rotation is slightly different from GoldSrc.
 

--- a/src/modules/campath/mod.rs
+++ b/src/modules/campath/mod.rs
@@ -78,9 +78,11 @@ static BXT_CAMPATH_ROTATE: CVar = CVar::new(
     "\
 Rotates all camera points around origin by Z up axis. HLAE CAM format is mainly for Source. But, Source horizontal rotation is slightly different from GoldSrc.
 
-If you have created campath in Blender based on map file exported from TrenchBroom or jack, you should set this value to 90. 
+If you want to import campath created in Blender based on map file exported from TrenchBroom or jack, you should set this value to 90. 
 
-Other tools such as Nem's Crafty are meant for Source. Its .OBJ export implicitly adds rotation. 
+If you want to export campath to Blender based on map file exported from TrenchBroom or jack, you should set this value to -90.
+
+Other tools such as Nem's Crafty are meant for Source. Its .OBJ export implicitly adds rotation. Therefore, you don't need to add rotation.
 ",
 );
 
@@ -310,18 +312,19 @@ pub fn capture_motion(marker: MainThreadMarker) {
         let r_refdef_viewangles = unsafe { &mut *engine::r_refdef_viewangles.get(marker) };
         let fov = unsafe { *engine::scr_fov_value.get(marker) };
 
+        let rotation_z = BXT_CAMPATH_ROTATE.as_f32(marker);
+        let rotated_vieworg = rotate_round_z(
+            glam::Vec3::from_slice(r_refdef_vieworg),
+            rotation_z.to_radians(),
+        );
+
         exporter.append_entry(
             TIME.get(marker),
-            [
-                r_refdef_vieworg[0],
-                r_refdef_vieworg[1],
-                r_refdef_vieworg[2],
-            ]
-            .into(),
+            rotated_vieworg,
             [
                 r_refdef_viewangles[2], // flip the order
                 r_refdef_viewangles[0],
-                r_refdef_viewangles[1],
+                r_refdef_viewangles[1] + rotation_z,
             ]
             .into(),
             fov,


### PR DESCRIPTION
To create a campath file inside Blender, there must be a map file in Blender. Usually, people use "Nem's Crafty" to export GoldSrc BSP into OBJ. However, Crafty is for Source. GoldSrc 90 degrees yaw is Source 0 degrees yaw or something. 

If people were to have the source file of the map, which is JMF or MAP, and they export that inside Blender, the OBJ has correct orientation for GoldSrc. And when exporting a campath created based on that source map file, HLAE Blender Plugins can mess up the rotation. The result is the campath and rotation look right in Blender, but not in the game.

After rotating the points with basic math, need to change the viewangles as well.