### PR TITLE
Add bxt_cvar_toggle, adjust, and cycle

### DIFF
--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -1489,6 +1489,23 @@ pub unsafe fn player_edict(marker: MainThreadMarker) -> Option<NonNull<edict_s>>
     }
 }
 
+// TODO: make good.
+pub unsafe fn find_cvar(marker: MainThreadMarker, name: &str) -> Option<*mut cvar_s> {
+    let mut ptr = *cvar_vars.get_opt(marker)?;
+    while !ptr.is_null() {
+        match std::ffi::CStr::from_ptr((*ptr).name).to_str() {
+            Ok(x) if x == name => {
+                return Some(ptr);
+            }
+            _ => (),
+        }
+
+        ptr = (*ptr).next;
+    }
+
+    None
+}
+
 /// # Safety
 ///
 /// [`reset_pointers()`] must be called before hw is unloaded so the pointers don't go stale.

--- a/src/modules/commands/handler.rs
+++ b/src/modules/commands/handler.rs
@@ -27,97 +27,44 @@ pub trait CommandHandler {
 // And if the lifetime is not explicit, then "as fn(_, _)" doesn't work because it wants "for<'r>
 // fn(&'r _, _)" or something.
 
-impl CommandHandler for fn(MainThreadMarker) {
-    unsafe fn handle(self, marker: MainThreadMarker) -> bool {
-        let args = Args::new(marker).skip(1);
-        if args.len() != 0 {
-            return false;
+macro_rules! impl_command_handler {
+    ($($arg:ident),*) => {
+        impl<$($arg: FromStr),*> CommandHandler for fn(MainThreadMarker, $($arg),*) {
+            unsafe fn handle(self, marker: MainThreadMarker) -> bool {
+                let mut args = Args::new(marker).skip(1);
+                let expected_len = 0 $(+ { let _ = stringify!($arg); 1 })*;
+
+                if args.len() != expected_len {
+                    return false;
+                }
+
+                $(
+                    let $arg = match args.next().and_then(|s| parse_arg::<$arg>(s)) {
+                        Some(val) => val,
+                        None => return false,
+                    };
+                )*
+
+                drop(args);
+                self(marker, $($arg),*);
+
+                true
+            }
         }
-
-        drop(args);
-        self(marker);
-
-        true
-    }
+    };
 }
 
-impl<A1: FromStr> CommandHandler for fn(MainThreadMarker, A1) {
-    unsafe fn handle(self, marker: MainThreadMarker) -> bool {
-        let mut args = Args::new(marker).skip(1);
-        if args.len() != 1 {
-            return false;
-        }
-
-        let a1 = if let Some(a1) = args.next().and_then(parse_arg) {
-            a1
-        } else {
-            return false;
-        };
-
-        drop(args);
-        self(marker, a1);
-
-        true
-    }
-}
-
-impl<A1: FromStr, A2: FromStr> CommandHandler for fn(MainThreadMarker, A1, A2) {
-    unsafe fn handle(self, marker: MainThreadMarker) -> bool {
-        let mut args = Args::new(marker).skip(1);
-        if args.len() != 2 {
-            return false;
-        }
-
-        let a1 = if let Some(a1) = args.next().and_then(parse_arg) {
-            a1
-        } else {
-            return false;
-        };
-
-        let a2 = if let Some(a2) = args.next().and_then(parse_arg) {
-            a2
-        } else {
-            return false;
-        };
-
-        drop(args);
-        self(marker, a1, a2);
-
-        true
-    }
-}
-
-impl<A1: FromStr, A2: FromStr, A3: FromStr> CommandHandler for fn(MainThreadMarker, A1, A2, A3) {
-    unsafe fn handle(self, marker: MainThreadMarker) -> bool {
-        let mut args = Args::new(marker).skip(1);
-        if args.len() != 3 {
-            return false;
-        }
-
-        let a1 = if let Some(a1) = args.next().and_then(parse_arg) {
-            a1
-        } else {
-            return false;
-        };
-
-        let a2 = if let Some(a2) = args.next().and_then(parse_arg) {
-            a2
-        } else {
-            return false;
-        };
-
-        let a3 = if let Some(a3) = args.next().and_then(parse_arg) {
-            a3
-        } else {
-            return false;
-        };
-
-        drop(args);
-        self(marker, a1, a2, a3);
-
-        true
-    }
-}
+impl_command_handler!();
+impl_command_handler!(A1);
+impl_command_handler!(A1, A2);
+impl_command_handler!(A1, A2, A3);
+impl_command_handler!(A1, A2, A3, A4);
+impl_command_handler!(A1, A2, A3, A4, A5);
+impl_command_handler!(A1, A2, A3, A4, A5, A6);
+impl_command_handler!(A1, A2, A3, A4, A5, A6, A7);
+impl_command_handler!(A1, A2, A3, A4, A5, A6, A7, A8);
+impl_command_handler!(A1, A2, A3, A4, A5, A6, A7, A8, A9);
+impl_command_handler!(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10);
 
 /// Wraps a function accepting `FromStr` arguments as a console command handler.
 ///

--- a/src/modules/cvar_toggle.rs
+++ b/src/modules/cvar_toggle.rs
@@ -1,0 +1,378 @@
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+
+use super::Module;
+use crate::handler;
+use crate::hooks::engine::{self, con_print, find_cvar, prepend_command};
+use crate::modules::commands::Command;
+use crate::modules::cvars::CVar;
+use crate::utils::*;
+
+pub struct CVarToggle;
+
+impl Module for CVarToggle {
+    fn name(&self) -> &'static str {
+        "CVar Toggle"
+    }
+
+    fn description(&self) -> &'static str {
+        "Toggling and adjusting cvars and commands"
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        engine::cvar_vars.is_set(marker)
+    }
+
+    fn commands(&self) -> &'static [&'static super::commands::Command] {
+        static COMMANDS: &[&Command] = &[&BXT_CVAR_ADJUST, &BXT_CVAR_TOGGLE, &BXT_CVAR_CYCLE];
+        COMMANDS
+    }
+
+    fn cvars(&self) -> &'static [&'static CVar] {
+        &[]
+    }
+}
+
+static CVAR_TOGGLES: Lazy<
+    MainThreadRefCell<
+        HashMap<
+            // cvar name
+            String,
+            // (current value, list of values)
+            (usize, Vec<String>),
+        >,
+    >,
+> = Lazy::new(|| MainThreadRefCell::new(HashMap::new()));
+
+static CVAR_CYCLES: Lazy<
+    MainThreadRefCell<
+        HashMap<
+            // hash of the cycle
+            String,
+            // (current value, list of values)
+            (usize, Vec<String>),
+        >,
+    >,
+> = Lazy::new(|| MainThreadRefCell::new(HashMap::new()));
+static BXT_CVAR_TOGGLE: Command = Command::new(
+    b"bxt_cvar_toggle\0",
+    handler!(
+        "bxt_cvar_toggle <cvar> <value 1> <value 2> <value 3> ...
+
+Cycles values given a cvar or command. Supports up to 9 values.",
+        cvar_toggle as fn(_, _),
+        cvar_toggle3 as fn(_, _, _, _),
+        cvar_toggle4 as fn(_, _, _, _, _),
+        cvar_toggle5 as fn(_, _, _, _, _, _),
+        cvar_toggle6 as fn(_, _, _, _, _, _, _),
+        cvar_toggle7 as fn(_, _, _, _, _, _, _, _),
+        cvar_toggle8 as fn(_, _, _, _, _, _, _, _, _),
+        cvar_toggle9 as fn(_, _, _, _, _, _, _, _, _, _),
+        cvar_toggle10 as fn(_, _, _, _, _, _, _, _, _, _, _)
+    ),
+);
+
+static BXT_CVAR_CYCLE: Command = Command::new(
+    b"bxt_cvar_cycle\0",
+    handler!(
+        "bxt_cvar_cycle <command 1> <command 2> <command 3> ...
+
+Cycles through a list of commands. Supports up to 9 commands.",
+        cvar_cycle as fn(_, _),
+        cvar_cycle2 as fn(_, _, _),
+        cvar_cycle3 as fn(_, _, _, _),
+        cvar_cycle4 as fn(_, _, _, _, _),
+        cvar_cycle5 as fn(_, _, _, _, _, _),
+        cvar_cycle6 as fn(_, _, _, _, _, _, _),
+        cvar_cycle7 as fn(_, _, _, _, _, _, _, _),
+        cvar_cycle8 as fn(_, _, _, _, _, _, _, _, _),
+        cvar_cycle9 as fn(_, _, _, _, _, _, _, _, _, _),
+        cvar_cycle10 as fn(_, _, _, _, _, _, _, _, _, _, _)
+    ),
+);
+
+static BXT_CVAR_ADJUST: Command = Command::new(
+    b"bxt_cvar_adjust\0",
+    handler!(
+        "bxt_cvar_adjust <cvar> <+/- value>
+
+Adjusts a cvar by a given value.",
+        cvar_adjust as fn(_, _, _)
+    ),
+);
+
+fn cvar_toggle3(marker: MainThreadMarker, arg1: String, arg2: String, arg3: String) {
+    cvar_toggle(marker, format!("{arg1} {arg2} {arg3}"));
+}
+
+fn cvar_toggle4(marker: MainThreadMarker, arg1: String, arg2: String, arg3: String, arg4: String) {
+    cvar_toggle(marker, format!("{arg1} {arg2} {arg3} {arg4}"));
+}
+
+fn cvar_toggle5(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+) {
+    cvar_toggle(marker, format!("{arg1} {arg2} {arg3} {arg4} {arg5}"));
+}
+
+fn cvar_toggle6(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+) {
+    cvar_toggle(marker, format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6}"));
+}
+
+fn cvar_toggle7(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+) {
+    cvar_toggle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7}"),
+    );
+}
+
+fn cvar_toggle8(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+    arg8: String,
+) {
+    cvar_toggle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8}"),
+    );
+}
+
+fn cvar_toggle9(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+    arg8: String,
+    arg9: String,
+) {
+    cvar_toggle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {arg9}"),
+    );
+}
+
+fn cvar_toggle10(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+    arg8: String,
+    arg9: String,
+    arg10: String,
+) {
+    cvar_toggle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {arg9} {arg10}"),
+    );
+}
+
+fn cvar_toggle(marker: MainThreadMarker, args: String) {
+    let split = args
+        .split_whitespace()
+        .map(|x| x.to_owned())
+        .collect::<Vec<String>>();
+
+    // at least 3 arguments, cvar, a, b
+    if split.len() < 3 {
+        con_print(marker, "Invalid usage.\n");
+        con_print(marker, BXT_CVAR_TOGGLE.description());
+        return;
+    }
+
+    let cvar_name = &split[0];
+    let toggles = &split[1..];
+
+    let mut binding = CVAR_TOGGLES.borrow_mut(marker);
+    let (cvar_curr_toggle, cvar_toggles) = binding
+        .entry(cvar_name.clone())
+        .or_insert((0, toggles.iter().map(|x| x.to_string()).collect()));
+
+    // if not matching the length, we add new toggles
+    // and then toggle the first value
+    if cvar_toggles.len() != toggles.len() {
+        *cvar_toggles = toggles.iter().map(|x| x.to_string()).collect();
+        *cvar_curr_toggle = 0;
+    }
+
+    // the command is executed in the next frame, whatever
+    prepend_command(
+        marker,
+        format!("{} {}\n", cvar_name, cvar_toggles[*cvar_curr_toggle]).as_str(),
+    );
+
+    *cvar_curr_toggle = (*cvar_curr_toggle + 1) % cvar_toggles.len();
+}
+
+fn cvar_cycle2(marker: MainThreadMarker, arg1: String, arg2: String) {
+    cvar_cycle(marker, format!("{arg1} {arg2}"));
+}
+
+fn cvar_cycle3(marker: MainThreadMarker, arg1: String, arg2: String, arg3: String) {
+    cvar_cycle(marker, format!("{arg1} {arg2} {arg3}"));
+}
+
+fn cvar_cycle4(marker: MainThreadMarker, arg1: String, arg2: String, arg3: String, arg4: String) {
+    cvar_cycle(marker, format!("{arg1} {arg2} {arg3} {arg4}"));
+}
+
+fn cvar_cycle5(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+) {
+    cvar_cycle(marker, format!("{arg1} {arg2} {arg3} {arg4} {arg5}"));
+}
+
+fn cvar_cycle6(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+) {
+    cvar_cycle(marker, format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6}"));
+}
+
+fn cvar_cycle7(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+) {
+    cvar_cycle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7}"),
+    );
+}
+
+fn cvar_cycle8(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+    arg8: String,
+) {
+    cvar_cycle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8}"),
+    );
+}
+
+fn cvar_cycle9(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+    arg8: String,
+    arg9: String,
+) {
+    cvar_cycle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {arg9}"),
+    );
+}
+
+fn cvar_cycle10(
+    marker: MainThreadMarker,
+    arg1: String,
+    arg2: String,
+    arg3: String,
+    arg4: String,
+    arg5: String,
+    arg6: String,
+    arg7: String,
+    arg8: String,
+    arg9: String,
+    arg10: String,
+) {
+    cvar_cycle(
+        marker,
+        format!("{arg1} {arg2} {arg3} {arg4} {arg5} {arg6} {arg7} {arg8} {arg9} {arg10}"),
+    );
+}
+
+fn cvar_cycle(marker: MainThreadMarker, args: String) {
+    let new_cycle = args
+        .split_whitespace()
+        .map(|x| x.to_owned())
+        .collect::<Vec<String>>();
+
+    let cycle_hashable = args;
+
+    let mut binding = CVAR_CYCLES.borrow_mut(marker);
+    let (curr_command, commands) = binding
+        .entry(cycle_hashable)
+        .or_insert((0, new_cycle.iter().map(|x| x.to_string()).collect()));
+
+    prepend_command(marker, format!("{}\n", commands[*curr_command]).as_str());
+
+    *curr_command = (*curr_command + 1) % commands.len();
+}
+
+fn cvar_adjust(marker: MainThreadMarker, cvar_name: String, adjustment: f32) {
+    let Some(cvar) = (unsafe { find_cvar(marker, &cvar_name) }) else {
+        con_print(marker, "Cannot find cvar\n");
+        return;
+    };
+
+    // in case the cvar takes in a string, the value is always 0
+    // it is up to the user that they know what they are doing
+    let value = unsafe { (*cvar).value };
+    let new_value = value + adjustment;
+
+    prepend_command(marker, format!("{} {}\n", cvar_name, new_value).as_str());
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -26,6 +26,7 @@ pub mod capture;
 pub mod capture_skip_non_gameplay;
 pub mod capture_video_per_demo;
 pub mod comment_overflow_fix;
+pub mod cvar_toggle;
 pub mod demo_playback;
 pub mod disable_loading_text;
 pub mod emit_sound;
@@ -95,6 +96,7 @@ pub static MODULES: &[&dyn Module] = &[
     &commands::Commands,
     &comment_overflow_fix::CommentOverflowFix,
     &cvars::CVars,
+    &cvar_toggle::CVarToggle,
     &demo_playback::DemoPlayback,
     &disable_loading_text::DisableLoadingText,
     &emit_sound::EmitSound,

--- a/src/modules/tas_studio/mod.rs
+++ b/src/modules/tas_studio/mod.rs
@@ -36,7 +36,7 @@ use crate::ffi::cvar::cvar_s;
 use crate::ffi::usercmd::usercmd_s;
 use crate::handler;
 use crate::hooks::bxt::{OnTasPlaybackFrameData, BXT_IS_TAS_EDITOR_ACTIVE};
-use crate::hooks::engine::con_print;
+use crate::hooks::engine::{con_print, find_cvar};
 use crate::hooks::{bxt, client, engine, sdl};
 use crate::modules::tas_studio::editor::{CameraViewAdjustmentMode, MaxAccelYawOffsetMode};
 use crate::utils::*;
@@ -2376,23 +2376,6 @@ pub fn is_main_instance(marker: MainThreadMarker) -> bool {
 }
 
 pub unsafe fn with_m_rawinput_one<T>(marker: MainThreadMarker, f: impl FnOnce() -> T) -> T {
-    // TODO: make good.
-    unsafe fn find_cvar(marker: MainThreadMarker, name: &str) -> Option<*mut cvar_s> {
-        let mut ptr = *engine::cvar_vars.get_opt(marker)?;
-        while !ptr.is_null() {
-            match std::ffi::CStr::from_ptr((*ptr).name).to_str() {
-                Ok(x) if x == name => {
-                    return Some(ptr);
-                }
-                _ => (),
-            }
-
-            ptr = (*ptr).next;
-        }
-
-        None
-    }
-
     let m_rawinput = find_cvar(marker, "m_rawinput");
     let mut prev = None;
 


### PR DESCRIPTION
Both `bxt_cvar_toggle` and `bxt_cvar_cycle` are very similar. They all aim to do this.

```
   bind "4" "cycle_nade"
   alias "cycle_nade" "use weapon_smokegrenade; alias cycle_nade use weapon_flashbang"
   alias "cycle_nade" "use weapon_flashbang; alias cycle_nade use weapon_hegrenade"
   alias "cycle_nade" "use weapon_hegrenade; alias cycle_nade use weapon_molotov"
   alias "cycle_nade" "use weapon_molotov; alias cycle_nade use weapon_smokegrenade"
```

The only difference is that `cycle` doesn't need a cvar so it can be an arbitrary list of commands or aliases.

`bxt_cvar_adjust` is a totally different thing because you cannot do it easily with just alias (everything is hardcoded).

The motivation is that I want to see how it can affect scripted run.