### PR TITLE
Add custom menu HUD and implementations

### DIFF
--- a/src/ffi/cvar.rs
+++ b/src/ffi/cvar.rs
@@ -33,7 +33,7 @@ bitflags! {
 // [`*const c_char`]
 // instead of the generated [`*mut ...`]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct cvar_s {
     pub name: *const c_char,
     pub string: *const c_char,

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -2521,6 +2521,7 @@ pub mod exported {
 
             campath::on_cl_disconnect(marker);
             viewmodel_sway::on_cl_disconnnect(marker);
+            checkpoint_menu::on_cl_disconnnect(marker);
 
             CL_Disconnect.get(marker)();
         })

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -516,6 +516,7 @@ pub static hudSetViewAngles: Pointer<unsafe extern "C" fn(*const [c_float; 3])> 
         // yet does the exact opposite thing!
         Patterns(&[
             // 8684
+            pattern!(55 8B EC 8D 45 ?? 50 FF 15 ?? ?? ?? ?? 8B 45 ?? 83 C4 04 8B 08),
         ]),
         null_mut(),
     );
@@ -979,7 +980,10 @@ pub static VGUI2_DrawStringClient: Pointer<
 > = Pointer::empty_patterns(
     b"VGUI2_DrawStringClient\0",
     // 114th pointer in cl_enginefuncs.
-    Patterns(&[]),
+    Patterns(&[
+        // 8684
+        pattern!(55 8B EC 8B 0D ?? ?? ?? ?? 53 56 57 8B 01 FF 50 ?? 8B 4D),
+    ]),
     null_mut(),
 );
 pub static VideoMode_IsWindowed: Pointer<unsafe extern "C" fn() -> c_int> = Pointer::empty_patterns(

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -1489,6 +1489,23 @@ pub unsafe fn player_edict(marker: MainThreadMarker) -> Option<NonNull<edict_s>>
     }
 }
 
+// TODO: make good. - YaLTeR
+pub unsafe fn find_cvar(marker: MainThreadMarker, name: &str) -> Option<*mut cvar_s> {
+    let mut ptr = *cvar_vars.get_opt(marker)?;
+    while !ptr.is_null() {
+        match std::ffi::CStr::from_ptr((*ptr).name).to_str() {
+            Ok(x) if x == name => {
+                return Some(ptr);
+            }
+            _ => (),
+        }
+
+        ptr = (*ptr).next;
+    }
+
+    None
+}
+
 /// # Safety
 ///
 /// [`reset_pointers()`] must be called before hw is unloaded so the pointers don't go stale.

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -507,6 +507,18 @@ pub static hudGetViewAngles: Pointer<unsafe extern "C" fn(*mut [c_float; 3])> =
         ]),
         null_mut(),
     );
+pub static hudSetViewAngles: Pointer<unsafe extern "C" fn(*const [c_float; 3])> =
+    Pointer::empty_patterns(
+        b"hudSetViewAngles\0",
+        // 36th pointer in cl_enginefuncs.
+        //
+        // Be careful! The very previous function is hudGetViewAngles() which looks VERY similar,
+        // yet does the exact opposite thing!
+        Patterns(&[
+            // 8684
+        ]),
+        null_mut(),
+    );
 pub static idum: Pointer<*mut c_int> = Pointer::empty(
     // Not a real symbol name.
     b"idum\0",
@@ -962,6 +974,14 @@ pub static V_RenderView: Pointer<unsafe extern "C" fn()> = Pointer::empty_patter
     ]),
     my_V_RenderView as _,
 );
+pub static VGUI2_DrawStringClient: Pointer<
+    unsafe extern "C" fn(c_int, c_int, *const c_char, c_int, c_int, c_int) -> c_int,
+> = Pointer::empty_patterns(
+    b"VGUI2_DrawStringClient\0",
+    // 114th pointer in cl_enginefuncs.
+    Patterns(&[]),
+    null_mut(),
+);
 pub static VideoMode_IsWindowed: Pointer<unsafe extern "C" fn() -> c_int> = Pointer::empty_patterns(
     b"VideoMode_IsWindowed\0",
     // To find, first find GL_BeginRendering(). The first check is for the
@@ -1064,6 +1084,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &Host_ValidSave,
     &hudGetScreenInfo,
     &hudGetViewAngles,
+    &hudSetViewAngles,
     &idum,
     &movevars,
     &listener_origin,
@@ -1115,6 +1136,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &V_ApplyShake,
     &V_FadeAlpha,
     &V_RenderView,
+    &VGUI2_DrawStringClient,
     &VideoMode_IsWindowed,
     &VideoMode_GetCurrentVideoMode,
     &window_rect,
@@ -2661,6 +2683,7 @@ pub mod exported {
 
             let text = comment_overflow_fix::strip_prefix_comments(text);
             let text = scoreboard_remove::strip_showscores(marker, text);
+            let text = menu::handle_interact_custom_menu(marker, text);
 
             if tas_studio::should_skip_command(marker, text) {
                 return;
@@ -2679,6 +2702,7 @@ pub mod exported {
 
             let text = comment_overflow_fix::strip_prefix_comments(text);
             let text = scoreboard_remove::strip_showscores(marker, text);
+            let text = menu::handle_interact_custom_menu(marker, text);
 
             Cbuf_AddFilteredText.get(marker)(text);
         })
@@ -2691,6 +2715,7 @@ pub mod exported {
 
             let text = comment_overflow_fix::strip_prefix_comments(text);
             let text = scoreboard_remove::strip_showscores(marker, text);
+            let text = menu::handle_interact_custom_menu(marker, text);
 
             Cbuf_AddTextToBuffer.get(marker)(text, buffer);
         })

--- a/src/modules/checkpoint_menu.rs
+++ b/src/modules/checkpoint_menu.rs
@@ -22,7 +22,7 @@ impl Module for CheckpointMenu {
     }
 
     fn description(&self) -> &'static str {
-        "Checkpoint system with menu support."
+        "Checkpoint system with HUD menu."
     }
 
     fn commands(&self) -> &'static [&'static Command] {
@@ -48,7 +48,8 @@ static BXT_CHECKPOINT_MENU: Command = Command::new(
     handler!(
         "bxt_checkpoint_menu
 
-Toggles checkpoint menu.",
+Toggles checkpoint menu.
+Needs `sv_cheats` enabled.",
         toggle_menu as fn(_)
     ),
 );

--- a/src/modules/checkpoint_menu.rs
+++ b/src/modules/checkpoint_menu.rs
@@ -36,7 +36,7 @@ impl Module for CheckpointMenu {
     }
 
     fn is_enabled(&self, marker: MainThreadMarker) -> bool {
-        Commands.is_enabled(marker) && CVars.is_enabled(marker) 
+        Commands.is_enabled(marker) && CVars.is_enabled(marker)
         && menu::Menu.is_enabled(marker) && engine::svs.is_set(marker) // player_edict
         && player_movement_tracing::PlayerMovementTracing.is_enabled(marker)
         && engine::hudSetViewAngles.is_set(marker)

--- a/src/modules/checkpoint_menu.rs
+++ b/src/modules/checkpoint_menu.rs
@@ -151,7 +151,7 @@ fn create_checkpoint(marker: MainThreadMarker) {
     }
 }
 
-static GO_CHECKPOINT_COUNT: MainThreadRefCell<usize> = MainThreadRefCell::new(0);
+static GO_CHECKPOINT_COUNT: MainThreadCell<usize> = MainThreadCell::new(0);
 
 fn go_checkpoint(marker: MainThreadMarker) {
     let player = unsafe { player_edict(marker) };
@@ -197,7 +197,8 @@ fn go_checkpoint(marker: MainThreadMarker) {
     player.v.punchangle = [0f32; 3];
 
     // increment go checkpoint count
-    *GO_CHECKPOINT_COUNT.borrow_mut(marker) += 1;
+    let go_check_count = GO_CHECKPOINT_COUNT.get(marker);
+    GO_CHECKPOINT_COUNT.set(marker, go_check_count + 1);
 }
 
 fn go_last_checkpoint(marker: MainThreadMarker) {
@@ -219,8 +220,11 @@ fn go_start(marker: MainThreadMarker) {
     go_checkpoint(marker);
     (*CHECKPOINT_DATA.borrow_mut(marker)).clear();
 
+    // also reset timer and start timer again
+    prepend_command(marker, "bxt_timer_reset; bxt_timer_start\n");
+
     // reset go check count when go to start
-    *GO_CHECKPOINT_COUNT.borrow_mut(marker) = 0;
+    GO_CHECKPOINT_COUNT.set(marker, 0);
 }
 
 fn set_start(marker: MainThreadMarker) {
@@ -244,7 +248,7 @@ fn get_checkpoint_menu() -> menu::CustomMenu {
                 label: "GoCheck".into(),
                 callback: Arc::new(go_checkpoint),
                 extra_text: Some(Arc::new(move |marker| {
-                    format!("#{}", *GO_CHECKPOINT_COUNT.borrow(marker))
+                    format!("#{}", GO_CHECKPOINT_COUNT.get(marker))
                 })),
             },
             // 3

--- a/src/modules/checkpoint_menu.rs
+++ b/src/modules/checkpoint_menu.rs
@@ -1,0 +1,366 @@
+//! `Checkpoint Menu`
+
+use std::f32;
+use std::ffi::CStr;
+use std::sync::Arc;
+
+use super::Module;
+use crate::ffi::buttons::Buttons;
+use crate::ffi::edict::{self, edict_s};
+use crate::handler;
+use crate::hooks::engine::{self, con_print, find_cvar, player_edict, prepend_command};
+use crate::modules::commands::{Command, Commands};
+use crate::modules::cvars::{CVar, CVars};
+use crate::modules::menu::{self, CustomMenu, CustomMenuItem};
+use crate::modules::player_movement_tracing::{self, player_trace};
+use crate::utils::*;
+
+pub struct CheckpointMenu;
+impl Module for CheckpointMenu {
+    fn name(&self) -> &'static str {
+        "Checkpoint Menu"
+    }
+
+    fn description(&self) -> &'static str {
+        "Checkpoint system with menu support."
+    }
+
+    fn commands(&self) -> &'static [&'static Command] {
+        static COMMANDS: &[&Command] = &[&BXT_CHECKPOINT_MENU];
+        COMMANDS
+    }
+
+    fn cvars(&self) -> &'static [&'static CVar] {
+        static CVARS: &[&CVar] = &[&BXT_CHECKPOINT_WITH_VEL, &BXT_CHECKPOINT_CONDITION];
+        CVARS
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        Commands.is_enabled(marker) && CVars.is_enabled(marker) 
+        && menu::Menu.is_enabled(marker) && engine::svs.is_set(marker) // player_edict
+        && player_movement_tracing::PlayerMovementTracing.is_enabled(marker)
+        && engine::hudSetViewAngles.is_set(marker)
+    }
+}
+
+static BXT_CHECKPOINT_MENU: Command = Command::new(
+    b"bxt_checkpoint_menu\0",
+    handler!(
+        "bxt_checkpoint_menu
+
+Toggles checkpoint menu.",
+        toggle_menu as fn(_)
+    ),
+);
+
+static BXT_CHECKPOINT_WITH_VEL: CVar = CVar::new(
+    b"bxt_checkpoint_with_vel\0",
+    b"1\0",
+    "\
+Whether go checkpoint restores velocity.",
+);
+
+static BXT_CHECKPOINT_CONDITION: CVar = CVar::new(
+    b"bxt_checkpoint_condition\0",
+    b"3\0",
+    "\
+Condition to register a checkpoint.
+
+0: Ground only
+1: Ground + Ladder
+2: Ground + Ladder + Slide
+3: Any condition",
+);
+
+fn toggle_menu(marker: MainThreadMarker) {
+    if !CheckpointMenu.is_enabled(marker) {
+        return;
+    }
+
+    let custom_menu = get_checkpoint_menu();
+
+    let sv_cheats = unsafe { find_cvar(marker, "sv_cheats") };
+    let Some(sv_cheats) = sv_cheats else { return };
+    let sv_cheats_value = (unsafe { *sv_cheats }).value;
+
+    // sv_cheats is not enabled
+    if sv_cheats_value == 0. {
+        con_print(marker, "sv_cheats is not enabled\n");
+        return;
+    }
+
+    menu::toggle_menu_display(marker, custom_menu);
+}
+
+type Vec3 = [f32; 3];
+
+#[derive(Clone, Copy)]
+struct CheckPointEntry {
+    origin: Vec3,
+    viewangles: Vec3,
+    velocity: Vec3,
+    is_duck: bool,
+    gravity: f32,
+}
+
+static CHECKPOINT_DATA: MainThreadRefCell<Vec<CheckPointEntry>> = MainThreadRefCell::new(vec![]);
+static START_POINT: MainThreadCell<Option<CheckPointEntry>> = MainThreadCell::new(None);
+
+fn create_checkpoint(marker: MainThreadMarker) {
+    let Some(new_entry) = get_player_entry(marker) else {
+        return;
+    };
+
+    // SAFETY: should pass because get_player_entry() uses get_player_entity() internally
+    let player = get_player_entity(marker).unwrap();
+
+    let condition = BXT_CHECKPOINT_CONDITION.as_u64(marker);
+
+    let is_on_ground = player.v.flags.contains(edict::Flags::FL_ONGROUND);
+    let is_ladder = player.v.movetype == 5; // MOVETYPE_FLY
+    let is_slide = {
+        let mut origin_z_offset = player.v.origin;
+        origin_z_offset[2] -= 2.;
+
+        let trace_result = unsafe {
+            player_trace(
+                marker,
+                player.v.origin.into(),
+                origin_z_offset.into(),
+                if new_entry.is_duck {
+                    bxt_strafe::Hull::Ducked
+                } else {
+                    bxt_strafe::Hull::Standing
+                },
+            )
+        };
+
+        // player can still walk on this face. Only value immediately above it is slide-able
+        const SLANTED_FACE: f32 = f32::consts::FRAC_1_SQRT_2;
+
+        trace_result.plane_normal.z < SLANTED_FACE && trace_result.plane_normal.z > 0.
+    };
+
+    if (condition == 0 && is_on_ground)
+        || (condition == 1 && (is_ladder || is_on_ground))
+        || (condition == 2 && (is_slide || is_ladder || is_on_ground))
+        || condition == 3
+    {
+        (*CHECKPOINT_DATA.borrow_mut(marker)).push(new_entry);
+    }
+}
+
+static GO_CHECKPOINT_COUNT: MainThreadRefCell<usize> = MainThreadRefCell::new(0);
+
+fn go_checkpoint(marker: MainThreadMarker) {
+    let player = unsafe { player_edict(marker) };
+    let Some(mut player) = player else { return };
+    let player = unsafe { player.as_mut() };
+
+    let binding = CHECKPOINT_DATA.borrow_mut(marker);
+    let Some(CheckPointEntry {
+        origin,
+        viewangles,
+        velocity,
+        is_duck,
+        gravity,
+    }) = binding.last()
+    else {
+        return;
+    };
+
+    player.v.origin = *origin;
+
+    // can't just set viewangles directly
+    // player.v.v_angle = *viewangles;
+    unsafe { engine::hudSetViewAngles.get(marker)(viewangles) };
+
+    if BXT_CHECKPOINT_WITH_VEL.as_bool(marker) {
+        player.v.velocity = *velocity;
+    }
+
+    // whatever, maybe somebody in the future will turn that button into bitflag soon
+    if *is_duck {
+        player.v.flags.set(edict::Flags::FL_DUCKING, *is_duck);
+        player.v.button |= Buttons::IN_DUCK.bits() as i32;
+    }
+
+    player.v.gravity = *gravity;
+
+    // cs1.6 stamina reset
+    if is_game_dir(marker, "cstrike") {
+        player.v.fuser2 = 0.;
+    }
+
+    // annoying punchangle
+    player.v.punchangle = [0f32; 3];
+
+    // increment go checkpoint count
+    *GO_CHECKPOINT_COUNT.borrow_mut(marker) += 1;
+}
+
+fn go_last_checkpoint(marker: MainThreadMarker) {
+    (*CHECKPOINT_DATA.borrow_mut(marker)).pop();
+
+    go_checkpoint(marker);
+}
+
+fn go_start(marker: MainThreadMarker) {
+    // this is convoluted, isn't it
+    let Some(start_point) = START_POINT.get(marker) else {
+        return;
+    };
+
+    // only do things if there is start
+    (*CHECKPOINT_DATA.borrow_mut(marker)).clear();
+
+    (*CHECKPOINT_DATA.borrow_mut(marker)).push(start_point);
+    go_checkpoint(marker);
+    (*CHECKPOINT_DATA.borrow_mut(marker)).clear();
+
+    // reset go check count when go to start
+    *GO_CHECKPOINT_COUNT.borrow_mut(marker) = 0;
+}
+
+fn set_start(marker: MainThreadMarker) {
+    START_POINT.set(marker, get_player_entry(marker));
+}
+
+fn get_checkpoint_menu() -> menu::CustomMenu {
+    CustomMenu {
+        label: "Checkpoint Menu".to_string(),
+        items: vec![
+            // 1
+            CustomMenuItem::Action {
+                label: "CheckPoint".into(),
+                callback: Arc::new(create_checkpoint),
+                extra_text: Some(Arc::new(move |marker| {
+                    format!("#{}", CHECKPOINT_DATA.borrow(marker).len())
+                })),
+            },
+            // 2
+            CustomMenuItem::Action {
+                label: "GoCheck".into(),
+                callback: Arc::new(go_checkpoint),
+                extra_text: Some(Arc::new(move |marker| {
+                    format!("#{}", *GO_CHECKPOINT_COUNT.borrow(marker))
+                })),
+            },
+            // 3
+            CustomMenuItem::Empty,
+            // 4
+            CustomMenuItem::Action {
+                label: "Start".into(),
+                callback: Arc::new(go_start),
+                extra_text: None,
+            },
+            // 5
+            CustomMenuItem::Empty,
+            // 6
+            CustomMenuItem::Action {
+                label: "Last Checkpoint".into(),
+                callback: Arc::new(go_last_checkpoint),
+                extra_text: None,
+            },
+            // 7
+            CustomMenuItem::Action {
+                label: "Set Start".into(),
+                callback: Arc::new(set_start),
+                extra_text: Some(Arc::new(move |marker| {
+                    if START_POINT.get(marker).is_some() {
+                        "ON".into()
+                    } else {
+                        "OFF".into()
+                    }
+                })),
+            },
+            // Page 2
+            // 1
+            CustomMenuItem::Toggle {
+                label: "Restore Velocity".into(),
+                value: Arc::new(move |marker| BXT_CHECKPOINT_WITH_VEL.as_bool(marker)),
+                callback: Arc::new(move |marker| {
+                    let value = !BXT_CHECKPOINT_WITH_VEL.as_bool(marker);
+
+                    prepend_command(
+                        marker,
+                        format!(
+                            "{} {}\n",
+                            BXT_CHECKPOINT_WITH_VEL.name_str(),
+                            if value { "1" } else { "0" }
+                        )
+                        .as_str(),
+                    );
+                }),
+            },
+            // 2
+            {
+                let options = vec![
+                    "Ground".into(),
+                    "Ladder".into(),
+                    "Slide".into(),
+                    "Any".into(),
+                ];
+                let option_len = options.len() as u64;
+
+                CustomMenuItem::Cycle {
+                    label: "CP Condition".into(),
+                    options,
+                    value: Arc::new(move |marker| BXT_CHECKPOINT_CONDITION.as_u64(marker) as usize),
+                    callback: Arc::new(move |marker| {
+                        let value = (BXT_CHECKPOINT_CONDITION.as_u64(marker) + 1) % option_len;
+
+                        prepend_command(
+                            marker,
+                            format!("{} {}\n", BXT_CHECKPOINT_CONDITION.name_str(), value).as_str(),
+                        );
+                    }),
+                }
+            },
+        ],
+    }
+}
+
+fn get_player_entity<'a>(marker: MainThreadMarker) -> Option<&'a edict_s> {
+    let player = unsafe { player_edict(marker) }?;
+    let player = unsafe { player.as_ref() };
+
+    Some(player)
+}
+
+fn get_player_entry(marker: MainThreadMarker) -> Option<CheckPointEntry> {
+    let player = get_player_entity(marker)?;
+
+    let is_duck = (player.v.button & Buttons::IN_DUCK.bits() as i32) != 0
+        || (player.v.flags.contains(edict::Flags::FL_DUCKING));
+
+    let new_entry = CheckPointEntry {
+        origin: player.v.origin,
+        viewangles: player.v.v_angle,
+        velocity: player.v.velocity,
+        is_duck,
+        gravity: player.v.gravity,
+    };
+
+    Some(new_entry)
+}
+
+static GAME_DIR: MainThreadRefCell<Option<String>> = MainThreadRefCell::new(None);
+
+fn is_game_dir(marker: MainThreadMarker, what: &str) -> bool {
+    if let Some(game_dir) = GAME_DIR.borrow(marker).as_ref() {
+        return game_dir == what;
+    }
+
+    // need to set gamedir first
+    let game_dir = engine::com_gamedir
+        .get_opt(marker)
+        .and_then(|dir| unsafe { CStr::from_ptr(dir.cast()).to_str().ok() })
+        .unwrap_or("valve");
+
+    let rv = game_dir == what;
+
+    *GAME_DIR.borrow_mut(marker) = Some(game_dir.to_string());
+
+    rv
+}

--- a/src/modules/checkpoint_menu.rs
+++ b/src/modules/checkpoint_menu.rs
@@ -26,12 +26,23 @@ impl Module for CheckpointMenu {
     }
 
     fn commands(&self) -> &'static [&'static Command] {
-        static COMMANDS: &[&Command] = &[&BXT_CHECKPOINT_MENU];
+        static COMMANDS: &[&Command] = &[
+            &BXT_CHECKPOINT_MENU,
+            &BXT_CHECKPOINT_CREATE,
+            &BXT_CHECKPOINT_GOTO,
+            &BXT_CHECKPOINT_GOTO_START,
+            &BXT_CHECKPOINT_GOTO_LAST,
+            &BXT_CHECKPOINT_SET_START,
+        ];
         COMMANDS
     }
 
     fn cvars(&self) -> &'static [&'static CVar] {
-        static CVARS: &[&CVar] = &[&BXT_CHECKPOINT_WITH_VEL, &BXT_CHECKPOINT_CONDITION];
+        static CVARS: &[&CVar] = &[
+            &BXT_CHECKPOINT_WITH_VEL,
+            &BXT_CHECKPOINT_CONDITION,
+            &BXT_CHECKPOINT_RESET_ON_DISCONNECT,
+        ];
         CVARS
     }
 
@@ -54,6 +65,56 @@ Needs `sv_cheats` enabled.",
     ),
 );
 
+static BXT_CHECKPOINT_CREATE: Command = Command::new(
+    b"bxt_checkpoint_create\0",
+    handler!(
+        "bxt_checkpoint_create
+
+Creates a checkpoint",
+        create_checkpoint as fn(_)
+    ),
+);
+
+static BXT_CHECKPOINT_GOTO: Command = Command::new(
+    b"bxt_checkpoint_goto\0",
+    handler!(
+        "bxt_checkpoint_goto
+
+Gotos current checkpoint",
+        go_checkpoint as fn(_)
+    ),
+);
+
+static BXT_CHECKPOINT_GOTO_LAST: Command = Command::new(
+    b"bxt_checkpoint_goto_last\0",
+    handler!(
+        "bxt_checkpoint_goto_last
+
+Gotos last checkpoint and removes current checkpoint",
+        go_last_checkpoint as fn(_)
+    ),
+);
+
+static BXT_CHECKPOINT_GOTO_START: Command = Command::new(
+    b"bxt_checkpoint_goto_start\0",
+    handler!(
+        "bxt_checkpoint_goto_start
+
+Gotos start checkpoint and resets the run",
+        go_start as fn(_)
+    ),
+);
+
+static BXT_CHECKPOINT_SET_START: Command = Command::new(
+    b"bxt_checkpoint_set_start\0",
+    handler!(
+        "bxt_checkpoint_set_start
+
+Sets start checkpoint",
+        set_start as fn(_)
+    ),
+);
+
 static BXT_CHECKPOINT_WITH_VEL: CVar = CVar::new(
     b"bxt_checkpoint_with_vel\0",
     b"1\0",
@@ -73,22 +134,39 @@ Condition to register a checkpoint.
 3: Any condition",
 );
 
-fn toggle_menu(marker: MainThreadMarker) {
+static BXT_CHECKPOINT_RESET_ON_DISCONNECT: CVar = CVar::new(
+    b"bxt_checkpoint_reset_on_disconnect\0",
+    b"1\0",
+    "\
+Whether checkpoints and related data reset upon disconnect",
+);
+
+fn is_enabled(marker: MainThreadMarker) -> bool {
     if !CheckpointMenu.is_enabled(marker) {
-        return;
+        return false;
     }
 
-    let custom_menu = get_checkpoint_menu();
-
     let sv_cheats = unsafe { find_cvar(marker, "sv_cheats") };
-    let Some(sv_cheats) = sv_cheats else { return };
+    let Some(sv_cheats) = sv_cheats else {
+        return false;
+    };
     let sv_cheats_value = (unsafe { *sv_cheats }).value;
 
     // sv_cheats is not enabled
     if sv_cheats_value == 0. {
         con_print(marker, "sv_cheats is not enabled\n");
+        return false;
+    }
+
+    true
+}
+
+fn toggle_menu(marker: MainThreadMarker) {
+    if !is_enabled(marker) {
         return;
     }
+
+    let custom_menu = get_checkpoint_menu();
 
     menu::toggle_menu_display(marker, custom_menu);
 }
@@ -106,8 +184,13 @@ struct CheckPointEntry {
 
 static CHECKPOINT_DATA: MainThreadRefCell<Vec<CheckPointEntry>> = MainThreadRefCell::new(vec![]);
 static START_POINT: MainThreadCell<Option<CheckPointEntry>> = MainThreadCell::new(None);
+static GO_CHECKPOINT_COUNT: MainThreadCell<usize> = MainThreadCell::new(0);
 
 fn create_checkpoint(marker: MainThreadMarker) {
+    if !is_enabled(marker) {
+        return;
+    }
+
     let Some(new_entry) = get_player_entry(marker) else {
         return;
     };
@@ -151,9 +234,11 @@ fn create_checkpoint(marker: MainThreadMarker) {
     }
 }
 
-static GO_CHECKPOINT_COUNT: MainThreadCell<usize> = MainThreadCell::new(0);
-
 fn go_checkpoint(marker: MainThreadMarker) {
+    if !is_enabled(marker) {
+        return;
+    }
+
     let player = unsafe { player_edict(marker) };
     let Some(mut player) = player else { return };
     let player = unsafe { player.as_mut() };
@@ -202,12 +287,20 @@ fn go_checkpoint(marker: MainThreadMarker) {
 }
 
 fn go_last_checkpoint(marker: MainThreadMarker) {
+    if !is_enabled(marker) {
+        return;
+    }
+
     (*CHECKPOINT_DATA.borrow_mut(marker)).pop();
 
     go_checkpoint(marker);
 }
 
 fn go_start(marker: MainThreadMarker) {
+    if !is_enabled(marker) {
+        return;
+    }
+
     // this is convoluted, isn't it
     let Some(start_point) = START_POINT.get(marker) else {
         return;
@@ -322,6 +415,24 @@ fn get_checkpoint_menu() -> menu::CustomMenu {
                     }),
                 }
             },
+            // 3
+            CustomMenuItem::Toggle {
+                label: "Reset on Disconnect".into(),
+                value: Arc::new(move |marker| BXT_CHECKPOINT_RESET_ON_DISCONNECT.as_bool(marker)),
+                callback: Arc::new(move |marker| {
+                    let value = !BXT_CHECKPOINT_RESET_ON_DISCONNECT.as_bool(marker);
+
+                    prepend_command(
+                        marker,
+                        format!(
+                            "{} {}\n",
+                            BXT_CHECKPOINT_RESET_ON_DISCONNECT.name_str(),
+                            if value { "1" } else { "0" }
+                        )
+                        .as_str(),
+                    );
+                }),
+            },
         ],
     }
 }
@@ -368,4 +479,19 @@ fn is_game_dir(marker: MainThreadMarker, what: &str) -> bool {
     *GAME_DIR.borrow_mut(marker) = Some(game_dir.to_string());
 
     rv
+}
+
+fn reset_checkpoints(marker: MainThreadMarker) {
+    CHECKPOINT_DATA.borrow_mut(marker).clear();
+    START_POINT.set(marker, None);
+    GO_CHECKPOINT_COUNT.set(marker, 0);
+}
+
+pub fn on_cl_disconnnect(marker: MainThreadMarker) {
+    // resets on disconnect... unless 😳
+    if !BXT_CHECKPOINT_RESET_ON_DISCONNECT.as_bool(marker) {
+        return;
+    }
+
+    reset_checkpoints(marker);
 }

--- a/src/modules/checkpoint_menu.rs
+++ b/src/modules/checkpoint_menu.rs
@@ -261,6 +261,10 @@ fn go_checkpoint(marker: MainThreadMarker) {
     // player.v.v_angle = *viewangles;
     unsafe { engine::hudSetViewAngles.get(marker)(viewangles) };
 
+    // not moving after go check
+    // if not set to 0, player velocity will accumulate if BXT_CHECKPOINT_WITH_VEL = 0
+    player.v.velocity = [0f32; 3];
+
     if BXT_CHECKPOINT_WITH_VEL.as_bool(marker) {
         player.v.velocity = *velocity;
     }

--- a/src/modules/hud.rs
+++ b/src/modules/hud.rs
@@ -6,6 +6,7 @@ use glam::{IVec2, IVec4};
 
 use super::{tas_studio, Module};
 use crate::hooks::engine::{self, SCREENINFO};
+use crate::modules::menu;
 use crate::utils::*;
 
 pub struct Hud;
@@ -47,6 +48,13 @@ pub struct MultiLine<'a> {
     pos: IVec2,
 }
 
+pub struct MultiHUDLine<'a> {
+    marker: MainThreadMarker,
+    draw: &'a Draw,
+    pos: IVec2,
+    default_pos: IVec2,
+}
+
 impl Draw {
     pub fn string(&self, pos: IVec2, string: &[u8]) -> i32 {
         let string = CStr::from_bytes_with_nul(string).unwrap();
@@ -58,7 +66,7 @@ impl Draw {
         unsafe { engine::Draw_String.get(self.marker)(pos.x, pos.y, string.as_ptr()) }
     }
 
-    pub fn multi_line(&self, pos: IVec2) -> MultiLine {
+    pub fn multi_line(&'_ self, pos: IVec2) -> MultiLine<'_> {
         MultiLine {
             marker: self.marker,
             draw: self,
@@ -71,6 +79,23 @@ impl Draw {
             engine::Draw_FillRGBABlend.get(self.marker)(
                 pos.x, pos.y, size.x, size.y, rgba.x, rgba.y, rgba.z, rgba.w,
             );
+        }
+    }
+
+    // String that looks similar to classic HUD menu.
+    pub fn hud_string(&'_ self, pos: IVec2, string: &[u8], r: i32, g: i32, b: i32) -> i32 {
+        let string = CStr::from_bytes_with_nul(string).unwrap();
+        unsafe {
+            engine::VGUI2_DrawStringClient.get(self.marker)(pos.x, pos.y, string.as_ptr(), r, g, b)
+        }
+    }
+
+    pub fn multi_hud_line(&'_ self, pos: IVec2) -> MultiHUDLine<'_> {
+        MultiHUDLine {
+            marker: self.marker,
+            draw: self,
+            pos,
+            default_pos: pos,
         }
     }
 }
@@ -89,6 +114,28 @@ impl<'a> MultiLine<'a> {
     }
 }
 
+impl<'a> MultiHUDLine<'a> {
+    pub fn same_line(&mut self, string: &[u8], r: i32, g: i32, b: i32) -> i32 {
+        let rv = self.draw.hud_string(self.pos, string, r, g, b);
+
+        self.pos.x += rv;
+
+        rv
+    }
+
+    pub fn new_line(&mut self, string: &[u8], r: i32, g: i32, b: i32) -> i32 {
+        let rv = self.draw.hud_string(self.pos, string, r, g, b);
+        let font_height = 12.max(screen_info(self.marker).iCharHeight);
+
+        self.pos.y += font_height;
+
+        // reset x position because it is good
+        self.pos.x = self.default_pos.x;
+
+        rv
+    }
+}
+
 pub unsafe fn draw_hud(marker: MainThreadMarker) {
     if !Hud.is_enabled(marker) {
         return;
@@ -96,4 +143,5 @@ pub unsafe fn draw_hud(marker: MainThreadMarker) {
 
     let draw = Draw { marker };
     tas_studio::draw_hud(marker, &draw);
+    menu::draw_custom_menu(marker, &draw);
 }

--- a/src/modules/menu.rs
+++ b/src/modules/menu.rs
@@ -1,0 +1,487 @@
+//! `Custom Menu`
+
+use std::sync::Arc;
+
+use super::Module;
+use crate::hooks::engine::{self, prepend_command, SCREENINFO};
+use crate::modules::cvars::{CVar, CVars};
+use crate::modules::hud::{self, MultiHUDLine};
+use crate::utils::*;
+
+pub struct Menu;
+impl Module for Menu {
+    fn name(&self) -> &'static str {
+        "Custom Menu"
+    }
+
+    fn description(&self) -> &'static str {
+        "Drawing custom menu elements."
+    }
+
+    fn cvars(&self) -> &'static [&'static CVar] {
+        static CVARS: &[&CVar] = &[&BXT_MENU_ANCHOR];
+        CVARS
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        engine::VGUI2_DrawStringClient.is_set(marker)
+            && CVars.is_enabled(marker)
+            && hud::Hud.is_enabled(marker)
+            && engine::Cbuf_InsertText.is_set(marker) // prepend_command
+    }
+}
+
+static BXT_MENU_ANCHOR: CVar = CVar::new(
+    b"_bxt_menu_anchor\0",
+    b"20 x\0",
+    "\
+Location of custom menu in (x, y).
+
+If the second value (y) is a literal \"x\", it will automatically be decided by bxt-rs.
+",
+);
+
+fn get_anchor_location(marker: MainThreadMarker) -> (i32, i32) {
+    let value = BXT_MENU_ANCHOR.to_string(marker);
+
+    let values = value.split_ascii_whitespace().collect::<Vec<&str>>();
+
+    const DEFAULT_X: i32 = 20;
+    let get_default_y = || calculate_menu_y_pos(marker, LINE_COUNT);
+    
+    if values.len() != 2 {
+        return (DEFAULT_X, get_default_y());
+    } else {
+        let x = values[0].parse::<i32>().unwrap_or(DEFAULT_X);
+
+        let y = if values[1] == "x" {
+            get_default_y()
+        } else {
+            values[1].parse::<i32>().unwrap_or(get_default_y())
+        };
+
+        return (x, y);
+    }
+}
+
+type CustomMenuLabel = String;
+type CustomMenuCallback = Arc<dyn Fn(MainThreadMarker) + 'static + Send + Sync>;
+type CustomMenuToggleValue = Arc<dyn Fn(MainThreadMarker) -> bool + 'static + Send + Sync>;
+type CustomMenuCycleValue = Arc<dyn Fn(MainThreadMarker) -> usize + 'static + Send + Sync>;
+type CustomMenuItemExtraText = Arc<dyn Fn(MainThreadMarker) -> String + 'static + Send + Sync>;
+
+// TODO submenu should point to a reference instead of owning the submenu?
+// if the menu stucture is big, the cloning is wasteful and super nested.
+// but it is fine for now.
+#[derive(Clone)]
+pub enum CustomMenuItem {
+    SubMenu(CustomMenu),
+    Action {
+        label: CustomMenuLabel,
+        callback: CustomMenuCallback,
+        extra_text: Option<CustomMenuItemExtraText>,
+    },
+    /// [`CustomMenuItem::Toggle`] is created programmatically.
+    ///
+    /// Toggles ON and OFF for selected element.
+    Toggle {
+        label: CustomMenuLabel,
+        value: CustomMenuToggleValue,
+        /// Callback implementation must change the value
+        callback: CustomMenuCallback,
+    },
+    /// [`CustomMenuItem::Cycle`] is created programmatically.
+    ///
+    /// Cycles between defined options.
+    Cycle {
+        label: CustomMenuLabel,
+        options: Vec<String>,
+        value: CustomMenuCycleValue,
+        callback: CustomMenuCallback,
+    },
+    /// [`CustomMenuItem::CycleCommand`] is user-defined and created dynamically.
+    ///
+    /// The command manages its own state and does not change the program state.
+    CycleCommand {
+        label: CustomMenuLabel,
+        options: Vec<String>,
+        value: usize,
+        command: String,
+        /// Whether to exclude the selected option argument from the commmand.
+        ///
+        /// Seems pretty useless but maybe people will find a use for it.
+        exclude_option: bool,
+    },
+    /// Takes up space and does nothing.
+    Empty,
+}
+
+#[derive(Clone)]
+pub struct CustomMenu {
+    pub label: CustomMenuLabel,
+    pub items: Vec<CustomMenuItem>,
+}
+
+#[derive(Clone)]
+struct CustomMenuDisplay {
+    custom_menu: CustomMenu,
+    page: usize,
+}
+
+// Stack stucture of current menus.
+static CUSTOM_MENU_DISPLAY_STATE: MainThreadRefCell<Vec<CustomMenuDisplay>> =
+    MainThreadRefCell::new(Vec::new());
+
+// 7 item per menu page
+// "slot8" = previous page
+// "slot9" = next page
+// "slot10" = back to previous menu or close menu
+const PAGE_SIZE: usize = 7;
+const LINE_COUNT: usize = PAGE_SIZE 
++ 3 // slot8 slot9 slot10
++ 2 // title and title padding
+;
+
+pub fn draw_custom_menu(marker: MainThreadMarker, draw: &hud::Draw) {
+    if !Menu.is_enabled(marker) {
+        return;
+    }
+
+    let binding = CUSTOM_MENU_DISPLAY_STATE.borrow_mut(marker);
+    let Some(curr_menu_display) = binding.last() else {
+        return;
+    };
+
+    let (x_pos, y_pos) = get_anchor_location(marker);
+
+    let pos = (x_pos, y_pos);
+
+    let mut multi_line = draw.multi_hud_line(pos.into());
+
+    let draw_red = |s: &mut MultiHUDLine, x: &str| s.same_line(x.as_bytes(), 210, 24, 0);
+    let draw_white = |s: &mut MultiHUDLine, x: &str| s.same_line(x.as_bytes(), 255, 255, 255);
+    let draw_white_ln = |s: &mut MultiHUDLine, x: &str| s.new_line(x.as_bytes(), 255, 255, 255);
+    let draw_yellow_ln = |s: &mut MultiHUDLine, x: &str| s.new_line(x.as_bytes(), 255, 210, 64);
+    let draw_red_ln = |s: &mut MultiHUDLine, x: &str| s.new_line(x.as_bytes(), 210, 24, 0);
+
+    let padding = |s: &mut MultiHUDLine| draw_white_ln(s, "\0");
+
+    // draw title and page info
+    draw_white_ln(
+        &mut multi_line,
+        format!(
+            "{} (Page {}/{})\0",
+            curr_menu_display.custom_menu.label,
+            curr_menu_display.page + 1,
+            (curr_menu_display.custom_menu.items.len() + PAGE_SIZE - 1) / PAGE_SIZE
+        )
+        .as_str(),
+    );
+    padding(&mut multi_line);
+
+    // draw item menu
+    curr_menu_display
+        .custom_menu
+        .items
+        .iter()
+        .skip(curr_menu_display.page * PAGE_SIZE)
+        .take(PAGE_SIZE)
+        .enumerate()
+        .for_each(|(idx, item)| {
+            match item {
+                CustomMenuItem::SubMenu(CustomMenu { label, .. }) => {
+                    // write the option number label, it should be red
+                    draw_red(&mut multi_line, format!("{}. \0", idx + 1).as_str());
+
+                    // then write the actual text
+                    draw_white_ln(&mut multi_line, format!("{}\0", label).as_str());
+                }
+                CustomMenuItem::Action {
+                    label, extra_text, ..
+                } => {
+                    draw_red(&mut multi_line, format!("{}. \0", idx + 1).as_str());
+
+                    if let Some(extra_text) = extra_text {
+                        let extra_text = extra_text(marker);
+
+                        draw_white(&mut multi_line, format!("{} \0", label).as_str());
+                        draw_yellow_ln(&mut multi_line, format!("{}\0", extra_text).as_str());
+                    } else {
+                        draw_white_ln(&mut multi_line, format!("{}\0", label).as_str());
+                    }
+                }
+                CustomMenuItem::Toggle { label, value, .. } => {
+                    // write option number like always
+                    draw_red(&mut multi_line, format!("{}. \0", idx + 1).as_str());
+
+                    // write label, dont draw new line
+                    draw_white(&mut multi_line, format!("{}: \0", label).as_str());
+
+                    // write value in yellow and draw new line
+                    let value = value(marker);
+
+                    if value {
+                        draw_yellow_ln(&mut multi_line, format!("ON\0").as_str());
+                    } else {
+                        draw_red_ln(&mut multi_line, format!("OFF\0").as_str());
+                    }
+                }
+                CustomMenuItem::Cycle {
+                    label,
+                    options,
+                    value,
+                    ..
+                } => {
+                    draw_red(&mut multi_line, format!("{}. \0", idx + 1).as_str());
+                    draw_white(&mut multi_line, format!("{}: \0", label).as_str());
+
+                    let selected_index = value(marker);
+
+                    assert!(
+                        selected_index < options.len(),
+                        "menu select item outside of range"
+                    );
+
+                    draw_yellow_ln(
+                        &mut multi_line,
+                        format!("{}\0", options[selected_index]).as_str(),
+                    );
+                }
+                CustomMenuItem::CycleCommand {
+                    label,
+                    options,
+                    value,
+                    ..
+                } => {
+                    // the same as [`CustomMenuItem::CycleCommand`]
+                    draw_red(&mut multi_line, format!("{}. \0", idx + 1).as_str());
+                    draw_white(&mut multi_line, format!("{}\0", label).as_str());
+                    draw_yellow_ln(&mut multi_line, format!(" {}\0", options[*value]).as_str());
+                }
+                CustomMenuItem::Empty => {
+                    padding(&mut multi_line);
+                }
+            };
+        });
+
+    // draw empty lines if any
+    let current_page_item_count = curr_menu_display
+        .custom_menu
+        .items
+        .len()
+        .saturating_sub(curr_menu_display.page * PAGE_SIZE)
+        .min(PAGE_SIZE);
+
+    let pad_count = PAGE_SIZE - current_page_item_count;
+
+    for _ in 0..pad_count {
+        padding(&mut multi_line);
+    }
+
+    padding(&mut multi_line);
+
+    // draw navigation options
+    let is_on_page_1 = curr_menu_display.page == 0;
+    let can_go_next_page = curr_menu_display.page
+    // have to sat_sub so that 7 items won't spawn new menu
+        < (curr_menu_display.custom_menu.items.len().saturating_sub(1) / PAGE_SIZE);
+    let is_submenu = binding.len() > 1; // the name is not accurate cuz can stack multiple main menu
+
+    // previous
+    if !is_on_page_1 {
+        draw_red(&mut multi_line, "8. \0");
+        draw_white_ln(&mut multi_line, "Previous\0");
+    } else {
+        padding(&mut multi_line);
+    }
+
+    // next
+    if can_go_next_page {
+        draw_red(&mut multi_line, "9. \0");
+        draw_white_ln(&mut multi_line, "Next\0");
+    } else {
+        padding(&mut multi_line);
+    }
+
+    // close/black
+    // there is always option 0
+    draw_red(&mut multi_line, "0. \0");
+    if is_submenu {
+        draw_white_ln(&mut multi_line, "Back\0");
+    } else {
+        draw_white_ln(&mut multi_line, "Close\0");
+    }
+}
+
+pub fn handle_interact_custom_menu(marker: MainThreadMarker, text: *const i8) -> *const i8 {
+    if !Menu.is_enabled(marker) {
+        return text;
+    }
+
+    if text.is_null() {
+        return text;
+    }
+
+    let mut binding = CUSTOM_MENU_DISPLAY_STATE.borrow_mut(marker);
+
+    let Some(curr_menu_display) = binding.last_mut() else {
+        return text;
+    };
+
+    let mut text_mut: *const u8 = text.cast();
+
+    let matching_progressive_f = |needle: &[u8], mut haystack: *const u8| {
+        for bytes in needle {
+            if unsafe { *haystack } != *bytes {
+                return None;
+            }
+
+            haystack = unsafe { haystack.add(1) };
+        }
+
+        Some(haystack)
+    };
+
+    // TODO, this is bad, will match any command starting with `slotN`
+    // but it is good enough for now
+    // prefix "slot"
+    if let Some(new_text_mut) = matching_progressive_f(b"slot", text_mut) {
+        text_mut = new_text_mut;
+    } else {
+        return text;
+    };
+
+    // then parse numbers
+    let options = [
+        "10", // parse 10 first becuase it has prefix "1"
+        "1", "2", "3", "4", "5", "6", "7", "8", "9",
+    ];
+
+    let is_on_page_1 = curr_menu_display.page == 0;
+    let can_go_next_page = curr_menu_display.page
+        < (curr_menu_display.custom_menu.items.len().saturating_sub(1) / PAGE_SIZE);
+
+    for (idx, option) in options.iter().enumerate() {
+        if let Some(new_text_mut) = matching_progressive_f(option.as_bytes(), text_mut) {
+            // matched option idx
+            match idx {
+                1..=7 => {
+                    // 1-7 = menu items
+                    let item_idx = curr_menu_display.page * PAGE_SIZE + (idx - 1);
+
+                    if let Some(item) = curr_menu_display.custom_menu.items.get_mut(item_idx) {
+                        match item {
+                            CustomMenuItem::SubMenu(submenu) => {
+                                let submenu_cloned = submenu.clone();
+
+                                // need to drop to change the borrow
+                                // otherwise epic panic happens
+                                drop(binding);
+
+                                let mut binding = CUSTOM_MENU_DISPLAY_STATE.borrow_mut(marker);
+
+                                binding.push(CustomMenuDisplay {
+                                    custom_menu: submenu_cloned,
+                                    page: 0,
+                                });
+                            }
+                            CustomMenuItem::Action { callback, .. }
+                            | CustomMenuItem::Toggle { callback, .. }
+                            | CustomMenuItem::Cycle { callback, .. } => {
+                                callback(marker);
+                            }
+                            CustomMenuItem::CycleCommand {
+                                options,
+                                command,
+                                value: selected_index,
+                                exclude_option,
+                                ..
+                            } => {
+                                *selected_index = (*selected_index + 1) % options.len();
+
+                                let formatted_command = format!(
+                                    "{} {}\0",
+                                    command,
+                                    if *exclude_option {
+                                        ""
+                                    } else {
+                                        options[*selected_index].as_str()
+                                    }
+                                );
+
+                                prepend_command(marker, formatted_command.as_str());
+                            }
+                            CustomMenuItem::Empty => (),
+                        }
+                    }
+                }
+                8 => {
+                    // 8 = previous page
+                    if !is_on_page_1 {
+                        curr_menu_display.page -= 1;
+                    }
+                }
+                9 => {
+                    // 9 = next page
+                    if can_go_next_page {
+                        curr_menu_display.page += 1;
+                    }
+                }
+                0 => {
+                    // 10 = back/close
+                    binding.pop();
+                }
+                _ => unreachable!("more than 10 options matched"),
+            }
+
+            text_mut = new_text_mut;
+
+            return text_mut.cast();
+        }
+    }
+
+    // no matched index, meaning it is `slotBOGUS`
+    // return original text
+    text
+}
+
+/// Returns boolean indicating whether the menu is on or off
+pub fn toggle_menu_display(marker: MainThreadMarker, custom_menu: CustomMenu) -> bool {
+    let mut binding = CUSTOM_MENU_DISPLAY_STATE.borrow_mut(marker);
+
+    // if menu is on top then close it
+    if binding
+        .last()
+        .is_some_and(|x| x.custom_menu.label == custom_menu.label)
+    {
+        binding.clear();
+        return false;
+    };
+
+    // clear menu cuz stacking main menu seems bad
+    binding.clear();
+
+    binding.push(CustomMenuDisplay {
+        custom_menu,
+        page: 0,
+    });
+
+    return true;
+}
+
+fn calculate_menu_y_pos(marker: MainThreadMarker, entry_count: usize) -> i32 {
+    let SCREENINFO {
+        iSize: _,
+        iWidth: _,
+        iHeight,
+        iFlags: _,
+        iCharHeight,
+        charWidths: _,
+    } = hud::screen_info(marker);
+
+    // must be consistent with the font height used in MultiHUDLine
+    let font_height = 12.max(iCharHeight);
+
+    // pulled from CHudMenu::Draw in cl_dll/menu.cpp
+    (iHeight / 2) - ((entry_count as i32 / 2) * font_height) - (3 * font_height + font_height / 3)
+}

--- a/src/modules/menu.rs
+++ b/src/modules/menu.rs
@@ -388,7 +388,13 @@ pub fn handle_interact_custom_menu(marker: MainThreadMarker, text: *const i8) ->
                             CustomMenuItem::Action { callback, .. }
                             | CustomMenuItem::Toggle { callback, .. }
                             | CustomMenuItem::Cycle { callback, .. } => {
-                                callback(marker);
+                                // WTF??? Windows???
+                                // Windows will crash if I don't do this.
+                                let cloned_cb = callback.clone();
+
+                                drop(binding);
+
+                                cloned_cb(marker);
                             }
                             CustomMenuItem::CycleCommand {
                                 options,
@@ -408,6 +414,9 @@ pub fn handle_interact_custom_menu(marker: MainThreadMarker, text: *const i8) ->
                                         options[*selected_index].as_str()
                                     }
                                 );
+
+                                // Windows will crash if I don't do this
+                                drop(binding);
 
                                 prepend_command(marker, formatted_command.as_str());
                             }

--- a/src/modules/menu.rs
+++ b/src/modules/menu.rs
@@ -170,7 +170,7 @@ pub fn draw_custom_menu(marker: MainThreadMarker, draw: &hud::Draw) {
     draw_white_ln(
         &mut multi_line,
         format!(
-            "{} (Page {}/{})\0",
+            "{} ({}/{})\0",
             curr_menu_display.custom_menu.label,
             curr_menu_display.page + 1,
             (curr_menu_display.custom_menu.items.len() + PAGE_SIZE - 1) / PAGE_SIZE

--- a/src/modules/menu.rs
+++ b/src/modules/menu.rs
@@ -48,7 +48,7 @@ fn get_anchor_location(marker: MainThreadMarker) -> (i32, i32) {
 
     const DEFAULT_X: i32 = 20;
     let get_default_y = || calculate_menu_y_pos(marker, LINE_COUNT);
-    
+
     if values.len() != 2 {
         return (DEFAULT_X, get_default_y());
     } else {
@@ -137,7 +137,7 @@ static CUSTOM_MENU_DISPLAY_STATE: MainThreadRefCell<Vec<CustomMenuDisplay>> =
 // "slot9" = next page
 // "slot10" = back to previous menu or close menu
 const PAGE_SIZE: usize = 7;
-const LINE_COUNT: usize = PAGE_SIZE 
+const LINE_COUNT: usize = PAGE_SIZE
 + 3 // slot8 slot9 slot10
 + 2 // title and title padding
 ;

--- a/src/modules/menu.rs
+++ b/src/modules/menu.rs
@@ -15,7 +15,7 @@ impl Module for Menu {
     }
 
     fn description(&self) -> &'static str {
-        "Drawing custom menu elements."
+        "Drawing custom HUD menu."
     }
 
     fn cvars(&self) -> &'static [&'static CVar] {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -25,6 +25,7 @@ pub mod campath;
 pub mod capture;
 pub mod capture_skip_non_gameplay;
 pub mod capture_video_per_demo;
+pub mod checkpoint_menu;
 pub mod comment_overflow_fix;
 pub mod demo_playback;
 pub mod disable_loading_text;
@@ -36,6 +37,7 @@ pub mod help;
 pub mod hud;
 pub mod hud_scale;
 pub mod lightstyle;
+pub mod menu;
 pub mod novis;
 pub mod player_movement_tracing;
 pub mod remote_forbid;
@@ -51,6 +53,7 @@ pub mod tas_recording;
 pub mod tas_server_time_fix;
 pub mod tas_studio;
 pub mod triangle_drawing;
+pub mod user_defined_menu;
 pub mod viewmodel_remove;
 pub mod viewmodel_sway;
 pub mod wallhack;
@@ -92,6 +95,7 @@ pub static MODULES: &[&dyn Module] = &[
     &capture::Capture,
     &capture_skip_non_gameplay::CaptureSkipNonGameplay,
     &capture_video_per_demo::CaptureVideoPerDemo,
+    &checkpoint_menu::CheckpointMenu,
     &commands::Commands,
     &comment_overflow_fix::CommentOverflowFix,
     &cvars::CVars,
@@ -105,6 +109,7 @@ pub static MODULES: &[&dyn Module] = &[
     &hud::Hud,
     &hud_scale::HudScale,
     &lightstyle::LightStyle,
+    &menu::Menu,
     &novis::NoVis,
     &player_movement_tracing::PlayerMovementTracing,
     &remote_forbid::RemoteForbid,
@@ -120,6 +125,7 @@ pub static MODULES: &[&dyn Module] = &[
     &tas_server_time_fix::TasServerTimeFix,
     &tas_studio::TasStudio,
     &triangle_drawing::TriangleDrawing,
+    &user_defined_menu::UserDefinedMenu,
     &viewmodel_remove::ViewmodelRemove,
     &viewmodel_sway::ViewmodelSway,
     &wallhack::Wallhack,

--- a/src/modules/tas_studio/mod.rs
+++ b/src/modules/tas_studio/mod.rs
@@ -32,11 +32,10 @@ use super::tas_optimizer::{self, optim_init_internal, parameters, player_data};
 use super::triangle_drawing::{TriangleApi, TriangleDrawing};
 use super::{hud, Module};
 use crate::ffi::buttons::Buttons;
-use crate::ffi::cvar::cvar_s;
 use crate::ffi::usercmd::usercmd_s;
 use crate::handler;
 use crate::hooks::bxt::{OnTasPlaybackFrameData, BXT_IS_TAS_EDITOR_ACTIVE};
-use crate::hooks::engine::con_print;
+use crate::hooks::engine::{con_print, find_cvar};
 use crate::hooks::{bxt, client, engine, sdl};
 use crate::modules::tas_studio::editor::{CameraViewAdjustmentMode, MaxAccelYawOffsetMode};
 use crate::utils::*;
@@ -2376,23 +2375,6 @@ pub fn is_main_instance(marker: MainThreadMarker) -> bool {
 }
 
 pub unsafe fn with_m_rawinput_one<T>(marker: MainThreadMarker, f: impl FnOnce() -> T) -> T {
-    // TODO: make good.
-    unsafe fn find_cvar(marker: MainThreadMarker, name: &str) -> Option<*mut cvar_s> {
-        let mut ptr = *engine::cvar_vars.get_opt(marker)?;
-        while !ptr.is_null() {
-            match std::ffi::CStr::from_ptr((*ptr).name).to_str() {
-                Ok(x) if x == name => {
-                    return Some(ptr);
-                }
-                _ => (),
-            }
-
-            ptr = (*ptr).next;
-        }
-
-        None
-    }
-
     let m_rawinput = find_cvar(marker, "m_rawinput");
     let mut prev = None;
 

--- a/src/modules/user_defined_menu.rs
+++ b/src/modules/user_defined_menu.rs
@@ -20,7 +20,7 @@ impl Module for UserDefinedMenu {
     }
 
     fn description(&self) -> &'static str {
-        "Loads and display custom menu from a JSON file."
+        "Loads and displays custom menu from a JSON file."
     }
 
     fn commands(&self) -> &'static [&'static Command] {

--- a/src/modules/user_defined_menu.rs
+++ b/src/modules/user_defined_menu.rs
@@ -96,6 +96,18 @@ Example BXT checkpoint and timer commands.
                     \"command\": \"map c1a0\"
                 }
             ]
+        },
+        {
+            \"label\": \"Echo Test 2\",
+            \"options\": [
+                \"And\",
+                \"potentially\",
+                \"the\",
+                \"most\",
+                \"unstable!\"
+            ],
+            \"command\": \"echo hi\",
+            \"exclude_option\": true
         }
     ]
 }

--- a/src/modules/user_defined_menu.rs
+++ b/src/modules/user_defined_menu.rs
@@ -1,0 +1,197 @@
+//! `User Defined Custom Menu`
+
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use super::Module;
+use crate::handler;
+use crate::hooks::engine::{self, con_print, prepend_command};
+use crate::modules::commands::{Command, Commands};
+use crate::modules::menu::{self, CustomMenu, CustomMenuItem};
+use crate::utils::*;
+
+pub struct UserDefinedMenu;
+impl Module for UserDefinedMenu {
+    fn name(&self) -> &'static str {
+        "User Defined Custom Menu"
+    }
+
+    fn description(&self) -> &'static str {
+        "Loads and display custom menu from a JSON file."
+    }
+
+    fn commands(&self) -> &'static [&'static Command] {
+        static COMMANDS: &[&Command] = &[&BXT_MENU_LOAD];
+        COMMANDS
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        Commands.is_enabled(marker)
+            && menu::Menu.is_enabled(marker)
+            && engine::Cbuf_InsertText.is_set(marker) // prepend command
+    }
+}
+
+static BXT_MENU_LOAD: Command = Command::new(
+    b"bxt_menu_load\0",
+    handler!(
+        "bxt_menu_load
+
+Loads and displays custom menu from a JSON file.
+
+Example BXT checkpoint and timer commands.
+```json
+{
+    \"label\": \"Checkpoint Menu\",
+    \"items\": [
+        {
+            \"label\": \"CheckPoint\",
+            \"command\": \"bxt_ch_checkpoint_create\"
+        },
+        {
+            \"label\": \"GoCheck\",
+            \"command\": \"bxt_ch_checkpoint_goto\"
+        },
+        {
+            \"label\": \"Remove Checkpoint\",
+            \"command\": \"bxt_ch_checkpoint_remove\"
+        },
+        {
+            \"label\": \"Pause Timer\",
+            \"command\": \"bxt_timer_stop\"
+        },
+        {
+            \"label\": \"Start Timer\",
+            \"command\": \"bxt_timer_start\"
+        },
+        null,
+        {
+            \"label\": \"Reset Timer\",
+            \"command\": \"bxt_timer_reset\"
+        },
+        {
+            \"label\": \"Echo Test 1\",
+            \"options\": [
+                \"It's black\",
+                \"It's white\",
+                \"It's black\",
+                \"It's yeah yeah yeah\"
+            ],
+            \"command\": \"echo\"
+        },
+        null,
+        null,
+        {
+            \"label\": \"Nested Menu\",
+            \"items\": [
+                {
+                    \"label\": \"Quit\",
+                    \"command\": \"quit\"
+                },
+                {
+                    \"label\": \"map c1a0\",
+                    \"command\": \"map c1a0\"
+                }
+            ]
+        }
+    ]
+}
+```",
+        load_menu as fn(_, _)
+    ),
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct JsonMenu {
+    label: String,
+    items: Vec<JsonMenuItem>,
+}
+
+#[derive(Debug, Deserialize)]
+// untagged so that it is easier to write json
+#[serde(untagged, rename_all = "snake_case")]
+enum JsonMenuItem {
+    SubMenu(JsonMenu),
+    // need to put CycleCommand before Action
+    // so that serde can deserialize correctly
+    CycleCommand {
+        label: String,
+        options: Vec<String>,
+        command: String,
+        #[serde(default)]
+        exclude_option: bool,
+    },
+    Action {
+        label: String,
+        command: String,
+    },
+    Empty,
+}
+
+impl JsonMenu {
+    fn to_custom_menu(self) -> CustomMenu {
+        CustomMenu {
+            label: self.label,
+            items: self
+                .items
+                .into_iter()
+                .map(|item| item.to_custom_menu_item())
+                .collect(),
+        }
+    }
+}
+
+impl JsonMenuItem {
+    fn to_custom_menu_item(self) -> CustomMenuItem {
+        match self {
+            JsonMenuItem::SubMenu(json_menu) => CustomMenuItem::SubMenu(json_menu.to_custom_menu()),
+            JsonMenuItem::CycleCommand {
+                label,
+                options,
+                command,
+                exclude_option,
+            } => CustomMenuItem::CycleCommand {
+                label,
+                options,
+                value: 0,
+                command,
+                exclude_option,
+            },
+            JsonMenuItem::Action { label, command } => CustomMenuItem::Action {
+                label,
+                callback: Arc::new(move |marker| {
+                    // basically just execute console command/cvar
+                    prepend_command(marker, format!("{}\n", command).as_str());
+                }),
+                extra_text: None,
+            },
+            JsonMenuItem::Empty => CustomMenuItem::Empty,
+        }
+    }
+}
+
+fn load_menu(marker: MainThreadMarker, file_name: String) {
+    let Ok(mut file) = OpenOptions::new().read(true).open(&file_name) else {
+        con_print(marker, format!("Cannot open file {}\n", file_name).as_str());
+        return;
+    };
+
+    let mut s = String::new();
+    let Ok(_) = file.read_to_string(&mut s) else {
+        con_print(marker, "Cannot read file\n");
+        return;
+    };
+
+    let Ok(s_deser) = serde_json::from_str::<JsonMenu>(&s) else {
+        con_print(marker, "Failed to parse JSON menu file\n");
+        return;
+    };
+
+    let user_menu = s_deser.to_custom_menu();
+
+    menu::toggle_menu_display(marker, user_menu);
+}


### PR DESCRIPTION
Beside the base custom menu interface, I add some implementations including checkpoint system and user defined custom menu through a JSON file, which I include an example in the command help text.

This might be more convenient than binding keys. The initial motivation is that I have some people using BXT sometimes to test maps but then they have to bind keys just to use checkpoints.

Tested on Windows for the cases that I make myself so it works for what I have right now.

Main checkpont menu

<img width="1156" height="927" alt="image" src="https://github.com/user-attachments/assets/923500d0-9db4-4029-ad74-a3c6e8c95af6" />

<img width="1156" height="927" alt="image" src="https://github.com/user-attachments/assets/dca7cc28-2d0d-44e3-a789-42d74f445ec0" />

User defined JSON menu example

<img width="1156" height="927" alt="image" src="https://github.com/user-attachments/assets/34090fe3-ba2e-4c21-bcff-17b4befea575" />

