### PR TITLE
Disables Metamod when bxt-rs is hooked.

### DIFF
--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -512,6 +512,15 @@ pub static idum: Pointer<*mut c_int> = Pointer::empty(
     b"idum\0",
 );
 pub static listener_origin: Pointer<*mut [f32; 3]> = Pointer::empty(b"listener_origin\0");
+pub static LoadThisDll: Pointer<unsafe extern "C" fn(*mut c_char)> = Pointer::empty_patterns(
+    b"LoadThisDll\0",
+    // To find, search for "Too many DLLs, ignoring remainder".
+    Patterns(&[
+        // 8684
+        pattern!(55 8B EC 53 8B 5D ?? 57 53 E8 ?? ?? ?? ?? 8B F8 83 C4 04 85 FF 75),
+    ]),
+    my_LoadThisDll as _,
+);
 pub static Memory_Init: Pointer<unsafe extern "C" fn(*mut c_void, c_int) -> c_int> =
     Pointer::empty_patterns(
         b"Memory_Init\0",
@@ -1067,6 +1076,7 @@ static POINTERS: &[&dyn PointerTrait] = &[
     &idum,
     &movevars,
     &listener_origin,
+    &LoadThisDll,
     &Memory_Init,
     &Mem_Free,
     &paintbuffer,
@@ -2095,6 +2105,17 @@ pub mod exported {
     use super::*;
     use crate::gl;
     use crate::hooks::client;
+
+    #[export_name = "LoadThisDll"]
+    pub unsafe extern "C" fn my_LoadThisDll(dll_file_name: *mut c_char) {
+        abort_on_panic(move || {
+            let marker = MainThreadMarker::new();
+
+            disable_metamod::replace_dll_name(marker, dll_file_name);
+
+            LoadThisDll.get(marker)(dll_file_name);
+        });
+    }
 
     #[export_name = "Memory_Init"]
     pub unsafe extern "C" fn my_Memory_Init(buf: *mut c_void, size: c_int) -> c_int {

--- a/src/modules/disable_metamod.rs
+++ b/src/modules/disable_metamod.rs
@@ -1,0 +1,99 @@
+//! `Disabling Metamod`
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::path::PathBuf;
+
+use super::Module;
+use crate::hooks::{bxt, engine};
+use crate::utils::*;
+
+pub struct DisableMetamod;
+impl Module for DisableMetamod {
+    fn name(&self) -> &'static str {
+        "Disabling Metamod"
+    }
+
+    fn description(&self) -> &'static str {
+        "Metamod (and hence AmxModX) is disabled when used along with bxt-rs for game compatibility."
+    }
+
+    fn is_enabled(&self, marker: MainThreadMarker) -> bool {
+        engine::LoadThisDll.is_set(marker)
+        // BunnymodXT already has the featuer
+        && !bxt::BXT_TAS_LOAD_SCRIPT_FROM_STRING.is_set(marker)
+    }
+}
+
+const METAMOD_DLL_FILE_NAME: &str = "metamod";
+
+// have to replace the string in place
+// bool szDllFilename [8192];
+pub unsafe fn replace_dll_name(marker: MainThreadMarker, orig_dll_name: *mut c_char) {
+    if !DisableMetamod.is_enabled(marker) {
+        return;
+    }
+
+    let dll_name_str = CStr::from_ptr(orig_dll_name);
+    let dll_name_str_str = dll_name_str.to_string_lossy();
+
+    if !dll_name_str_str.contains(METAMOD_DLL_FILE_NAME) {
+        return;
+    }
+
+    info!("Found Metamod.");
+
+    let gamedir = engine::com_gamedir.get(marker);
+    let gamedir = CStr::from_ptr(gamedir as *mut i8);
+    let gamedir = gamedir.to_string_lossy();
+
+    if gamedir == "cstrike" {
+        let lib_dll = if cfg!(windows) {
+            "dlls\\mp.dll"
+        } else {
+            "dlls/cs.so"
+        };
+
+        // the dll path is actually the full path
+        // orig `"/home/khang/bxt/game_isolated/./cstrike/addons/metamod/dlls/metamod.so"`
+        // new `"dlls/cs.so"`
+        // instead of canonicalize the path, which does not work all the time depending
+        // on current working directory,
+        // just replace the string where it is needed
+        // rfind just to make sure that we don't have any weirdo doing weirdo stuffs
+        let Some(start) = dll_name_str_str.rfind("cstrike") else {
+            warn!("Failed to find the gamemod `cstrike` in the dll path.");
+            return;
+        };
+
+        // verify that the path exists
+        let lib_dll_path = PathBuf::from(&dll_name_str_str[..start])
+            .join("cstrike")
+            .join(lib_dll);
+
+        if !lib_dll_path.exists() {
+            warn!(
+                "Failed to locate original server library find at `{}`.",
+                lib_dll_path.display()
+            );
+            return;
+        }
+
+        let Ok(lib_dll) = CString::new(lib_dll) else {
+            return;
+        };
+
+        // bool szDllFilename [8192];
+        let Some(x) = (orig_dll_name as *mut [u8; 1024]).as_mut() else {
+            return;
+        };
+        let copy_start = start + gamedir.len() + 1; // + 1 for the slash
+        x[copy_start..(copy_start + lib_dll.as_bytes_with_nul().len())]
+            .copy_from_slice(lib_dll.as_bytes_with_nul());
+
+        info!("Successfully disabled Metamod.");
+        return;
+    }
+
+    info!("No attempt to disable Metamod was made.");
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -28,6 +28,7 @@ pub mod capture_video_per_demo;
 pub mod comment_overflow_fix;
 pub mod demo_playback;
 pub mod disable_loading_text;
+pub mod disable_metamod;
 pub mod emit_sound;
 pub mod fade_remove;
 pub mod fix_widescreen;
@@ -97,6 +98,7 @@ pub static MODULES: &[&dyn Module] = &[
     &cvars::CVars,
     &demo_playback::DemoPlayback,
     &disable_loading_text::DisableLoadingText,
+    &disable_metamod::DisableMetamod,
     &emit_sound::EmitSound,
     &fade_remove::FadeRemove,
     &fix_widescreen::FixWidescreen,


### PR DESCRIPTION
I sent a bunch of features to some other people the other day and they couldn't start a server. I was always under the impression that Metamod is compatible with bxt-rs. I guess not so much.

For now it only disables for `cstrike` game mod because it is the only thing that matters.

This is a port of https://github.com/YaLTeR/BunnymodXT/pull/508 