### PR TITLE
Allow launching multiple instances without BunnymodXT

### DIFF
--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -2086,6 +2086,41 @@ fn reset_pointers(marker: MainThreadMarker) {
     }
 }
 
+#[cfg(windows)]
+fn allow_multiple_instances() {
+    // trying to free launcher mutex
+    // to have multiple game instances
+    // BXT also tries doing the same thing but there is no conflict
+
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::synchapi::{OpenMutexW, ReleaseMutex};
+    use winapi::um::winnt::SYNCHRONIZE;
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+
+        OsStr::new(s)
+            .encode_wide()
+            // add null terminator
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let mutex_name = to_wide("ValveHalfLifeLauncherMutex");
+
+    // this mutex exists so need to open the exact mutex
+    // with OpenMutexW, not OpenMutexA
+    let mutex = unsafe { OpenMutexW(SYNCHRONIZE, 0, mutex_name.as_ptr()) };
+
+    if !mutex.is_null() {
+        unsafe {
+            ReleaseMutex(mutex);
+            CloseHandle(mutex);
+        }
+    }
+}
+
 use exported::*;
 
 /// Functions exported for `LD_PRELOAD` hooking.
@@ -2119,39 +2154,7 @@ pub mod exported {
                     maybe_hook(marker, pointer);
                 }
 
-                {
-                    // trying to free launcher mutex
-                    // to have multiple game instances
-                    // BXT also tries doing the same thing but there is no conflict
-
-                    use winapi::um::handleapi::CloseHandle;
-                    use winapi::um::synchapi::{OpenMutexW, ReleaseMutex};
-                    use winapi::um::winnt::SYNCHRONIZE;
-
-                    fn to_wide(s: &str) -> Vec<u16> {
-                        use std::ffi::OsStr;
-                        use std::os::windows::ffi::OsStrExt;
-
-                        OsStr::new(s)
-                            .encode_wide()
-                            // add null terminator
-                            .chain(std::iter::once(0))
-                            .collect()
-                    }
-
-                    // this mutex exists so need to open the exact mutex
-                    // with OpenMutexW, not OpenMutexA
-                    let mutex = OpenMutexW(
-                        SYNCHRONIZE,
-                        0,
-                        to_wide("ValveHalfLifeLauncherMutex").as_ptr(),
-                    );
-
-                    if !mutex.is_null() {
-                        ReleaseMutex(mutex);
-                        CloseHandle(mutex);
-                    }
-                }
+                allow_multiple_instances();
             }
 
             // GL_SetMode() happens before Memory_Init(), which means the OpenGL context has already

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -2040,6 +2040,10 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
 #[cfg(windows)]
 unsafe fn maybe_hook(marker: MainThreadMarker, pointer: &dyn PointerTrait) {
     use minhook_sys::*;
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::synchapi::ReleaseMutex;
+    use winapi::um::winbase::OpenMutexA;
+    use winapi::um::winnt::SYNCHRONIZE;
 
     if !pointer.is_set(marker) {
         return;
@@ -2066,6 +2070,19 @@ unsafe fn maybe_hook(marker: MainThreadMarker, pointer: &dyn PointerTrait) {
         NonNull::new_unchecked(trampoline),
         pointer.pattern_index(marker),
     );
+
+    // trying to free launcher mutex
+    // to have multiple game instances
+    let mutex = OpenMutexA(
+        SYNCHRONIZE,
+        0,
+        "ValveHalfLifeLauncherMutex".as_ptr() as *mut i8,
+    );
+
+    if !mutex.is_null() {
+        ReleaseMutex(mutex);
+        CloseHandle(mutex);
+    }
 
     assert_eq!(MH_EnableHook(original.as_ptr()), MH_OK);
 }

--- a/src/hooks/engine.rs
+++ b/src/hooks/engine.rs
@@ -2040,10 +2040,6 @@ pub unsafe fn find_pointers(marker: MainThreadMarker, base: *mut c_void, size: u
 #[cfg(windows)]
 unsafe fn maybe_hook(marker: MainThreadMarker, pointer: &dyn PointerTrait) {
     use minhook_sys::*;
-    use winapi::um::handleapi::CloseHandle;
-    use winapi::um::synchapi::ReleaseMutex;
-    use winapi::um::winbase::OpenMutexA;
-    use winapi::um::winnt::SYNCHRONIZE;
 
     if !pointer.is_set(marker) {
         return;
@@ -2070,19 +2066,6 @@ unsafe fn maybe_hook(marker: MainThreadMarker, pointer: &dyn PointerTrait) {
         NonNull::new_unchecked(trampoline),
         pointer.pattern_index(marker),
     );
-
-    // trying to free launcher mutex
-    // to have multiple game instances
-    let mutex = OpenMutexA(
-        SYNCHRONIZE,
-        0,
-        "ValveHalfLifeLauncherMutex".as_ptr() as *mut i8,
-    );
-
-    if !mutex.is_null() {
-        ReleaseMutex(mutex);
-        CloseHandle(mutex);
-    }
 
     assert_eq!(MH_EnableHook(original.as_ptr()), MH_OK);
 }
@@ -2134,6 +2117,40 @@ pub mod exported {
                     }
 
                     maybe_hook(marker, pointer);
+                }
+
+                {
+                    // trying to free launcher mutex
+                    // to have multiple game instances
+                    // BXT also tries doing the same thing but there is no conflict
+
+                    use winapi::um::handleapi::CloseHandle;
+                    use winapi::um::synchapi::{OpenMutexW, ReleaseMutex};
+                    use winapi::um::winnt::SYNCHRONIZE;
+
+                    fn to_wide(s: &str) -> Vec<u16> {
+                        use std::ffi::OsStr;
+                        use std::os::windows::ffi::OsStrExt;
+
+                        OsStr::new(s)
+                            .encode_wide()
+                            // add null terminator
+                            .chain(std::iter::once(0))
+                            .collect()
+                    }
+
+                    // this mutex exists so need to open the exact mutex
+                    // with OpenMutexW, not OpenMutexA
+                    let mutex = OpenMutexW(
+                        SYNCHRONIZE,
+                        0,
+                        to_wide("ValveHalfLifeLauncherMutex").as_ptr(),
+                    );
+
+                    if !mutex.is_null() {
+                        ReleaseMutex(mutex);
+                        CloseHandle(mutex);
+                    }
                 }
             }
 


### PR DESCRIPTION
Make it easier for people to use just bxt-rs. 

One incidental good usage of BunnymodXT is that it always "focuses" on the game when the game is not in focus, meaning no FPS drop. BXT also allows launching multiple instances. With those two combined, a streaming setup containing multiple views of the game.

This should be included in bxt-rs as some of the more features (for spectating) I recently developed for are only on bxt-rs.